### PR TITLE
fix: `addTabViewController`가 메모리에서 해제 안 되는 버그 수정

### DIFF
--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewController.swift
@@ -8,18 +8,18 @@
 import UIKit
 
 final class TabBarViewController: UITabBarController, ViewControllable {
-	private let checkListTabViewControllable: ViewControllable
-	private let addTabViewControllable: ViewControllable
-	private let recommendTabViewControllable: ViewControllable
+	private let checkListTabFactoryable: CheckListTableFactoryable
+	private let addTabFactoryable: AddTabFactoryable
+	private let recommendTabFactoryable: RecommendTabFactoryable
 	
 	init(
-		checkListTabViewControllable: ViewControllable,
-		addTabViewControllable: ViewControllable,
-		recommendTabViewControllable: ViewControllable
+		checkListTabFactoryable: CheckListTableFactoryable,
+		addTabFactoryable: AddTabFactoryable,
+		recommendTabFactoryable: RecommendTabFactoryable
 	) {
-		self.checkListTabViewControllable = checkListTabViewControllable
-		self.addTabViewControllable = addTabViewControllable
-		self.recommendTabViewControllable = recommendTabViewControllable
+		self.checkListTabFactoryable = checkListTabFactoryable
+		self.addTabFactoryable = addTabFactoryable
+		self.recommendTabFactoryable = recommendTabFactoryable
 		super.init(nibName: nil, bundle: nil)
 	}
 	
@@ -36,9 +36,11 @@ final class TabBarViewController: UITabBarController, ViewControllable {
 		emptyViewController.view.backgroundColor = .systemBackground
 		emptyViewController.tabBarItem = makeTabBarItem(of: .addTab)
 		
+		let checkListTabViewControllable = checkListTabFactoryable.make()
 		let checkListTabNavigationController = makeTabNavigationController(of: checkListTabViewControllable)
 		checkListTabNavigationController.navigationController.tabBarItem = makeTabBarItem(of: .checklistTab)
 		
+		let recommendTabViewControllable = recommendTabFactoryable.make()
 		let recommendTabNavigationController = makeTabNavigationController(of: recommendTabViewControllable)
 		recommendTabNavigationController.navigationController.tabBarItem = makeTabBarItem(of: .recommendTab)
 		self.viewControllers = [
@@ -75,6 +77,7 @@ extension TabBarViewController: UITabBarControllerDelegate {
 		shouldSelect viewController: UIViewController
 	) -> Bool {
 		if viewController.tabBarItem.tag == TabBarPage.addTab.pageOrderNumber() {
+			let addTabViewControllable = addTabFactoryable.make()
 			let addTabNavigationViewController = makeTabNavigationController(of: addTabViewControllable)
 			present(addTabNavigationViewController.uiviewController, animated: true)
 			return false

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewFactory.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewFactory.swift
@@ -53,9 +53,9 @@ final class TabBarViewFactory: Factory<TabBarDependency>, TabBarFactoryable {
 	func make() -> ViewControllable {
 		let component = TabBarComponent(parent: parent)
 		let tabBarViewController = TabBarViewController(
-			checkListTabViewControllable: component.checklistTabFactoryable.make(),
-			addTabViewControllable: component.addTabFactoryable.make(),
-			recommendTabViewControllable: component.recommendTabFactoryable.make()
+			checkListTabFactoryable: component.checklistTabFactoryable,
+			addTabFactoryable: component.addTabFactoryable,
+			recommendTabFactoryable: component.recommendTabFactoryable
 		)
 		return tabBarViewController
 	}


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #45 

## 고민과 해결 과정
- TabViewController가 ViewController를 프로퍼티로 가지고 있지 않고 Factory를 가지고 있도록 변경하였습니다.

## 스크린샷
<img width="785" alt="image" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/48887389/66346299-ca18-4deb-a898-f18744ed7cf7">

## 테스트 결과(커버리지/테스트 결과)

https://github.com/boostcampwm2023/iOS10-OpenList/assets/48887389/5e6e329d-88b5-40bc-aac1-adcd8efcb865



close #45 