### PR TITLE
[Server] access 토큰 재발급시 유저 정보 없는 버그 수정

### DIFF
--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -1,11 +1,11 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
+import { CreateUserDto } from 'src/users/dto/create-user.dto';
 import { ProviderType, UserModel } from 'src/users/entities/user.entity';
 import { UsersService } from 'src/users/users.service';
 import { AuthService } from './auth.service';
 import { loginUserDto } from './dto/login-user.dto';
-import { registerUserDto } from './dto/register-user.dto';
 
 describe('AuthService', () => {
   let authService: AuthService;
@@ -39,7 +39,7 @@ describe('AuthService', () => {
   });
   describe('signToken', () => {
     it('유저 정보로 access 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', userId: 1 };
+      const user = { email: 'test@example.com', userId: 1 } as UserModel;
       const token = 'access_token';
       jest.spyOn(jwtService, 'sign').mockReturnValue(token);
 
@@ -53,7 +53,7 @@ describe('AuthService', () => {
     });
 
     it('유저 정보로 refresh 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', userId: 1 };
+      const user = { email: 'test@example.com', userId: 1 } as UserModel;
       const token = 'refresh_token';
       jest.spyOn(jwtService, 'sign').mockReturnValue(token);
 
@@ -123,7 +123,7 @@ describe('AuthService', () => {
 
   describe('loginUser', () => {
     it('유저 정보로 access 토큰과 refresh 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', userId: 1 };
+      const user = { email: 'test@example.com', userId: 1 } as UserModel;
       const accessToken = 'access_token';
       const refreshToken = 'refresh_token';
       jest
@@ -228,10 +228,11 @@ describe('AuthService', () => {
 
   describe('registerUser', () => {
     it('유저를 등록하고 토큰을 발급한다.', async () => {
-      const user: registerUserDto = {
+      const user: CreateUserDto = {
         email: 'newuser@example.com',
         provider: ProviderType.APPLE,
-        nickname: 'NewUser',
+        fullName: 'NewUser',
+        providerId: '1234567890',
       };
       const newUser = { ...user, userId: 3 } as UserModel;
       jest.spyOn(usersService, 'createUser').mockResolvedValue(newUser);

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -39,7 +39,7 @@ describe('AuthService', () => {
   });
   describe('signToken', () => {
     it('유저 정보로 access 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', id: 1 };
+      const user = { email: 'test@example.com', userId: 1 };
       const token = 'access_token';
       jest.spyOn(jwtService, 'sign').mockReturnValue(token);
 
@@ -53,7 +53,7 @@ describe('AuthService', () => {
     });
 
     it('유저 정보로 refresh 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', id: 1 };
+      const user = { email: 'test@example.com', userId: 1 };
       const token = 'refresh_token';
       jest.spyOn(jwtService, 'sign').mockReturnValue(token);
 
@@ -123,7 +123,7 @@ describe('AuthService', () => {
 
   describe('loginUser', () => {
     it('유저 정보로 access 토큰과 refresh 토큰을 발급한다.', () => {
-      const user = { email: 'test@example.com', id: 1 };
+      const user = { email: 'test@example.com', userId: 1 };
       const accessToken = 'access_token';
       const refreshToken = 'refresh_token';
       jest
@@ -145,7 +145,7 @@ describe('AuthService', () => {
         email: 'test@example.com',
         provider: 'APPLE',
       };
-      const existUser = { ...user, id: 1 } as UserModel;
+      const existUser = { ...user, userId: 1 } as UserModel;
       jest.spyOn(usersService, 'findUserByEmail').mockResolvedValue(existUser);
 
       const result = await authService.authenticateWithEmailAndProvider(user);
@@ -171,7 +171,7 @@ describe('AuthService', () => {
         email: 'test@example.com',
         provider: 'GOOGLE',
       };
-      const existUser = { ...user, provider: 'APPLE', id: 1 } as UserModel;
+      const existUser = { ...user, provider: 'APPLE', userId: 1 } as UserModel;
       jest.spyOn(usersService, 'findUserByEmail').mockResolvedValue(existUser);
 
       await expect(
@@ -186,7 +186,7 @@ describe('AuthService', () => {
         email: 'test@example.com',
         provider: 'APPLE',
       };
-      const existUser = { email: user.email, id: 1 } as UserModel;
+      const existUser = { email: user.email, userId: 1 } as UserModel;
       jest
         .spyOn(authService, 'authenticateWithEmailAndProvider')
         .mockResolvedValue(existUser);
@@ -233,7 +233,7 @@ describe('AuthService', () => {
         provider: 'APPLE',
         nickname: 'NewUser',
       };
-      const newUser = { ...user, id: 3 } as UserModel;
+      const newUser = { ...user, userId: 3 } as UserModel;
       jest.spyOn(usersService, 'createUser').mockResolvedValue(newUser);
       jest.spyOn(authService, 'loginUser').mockReturnValue({
         accessToken: 'access_token',

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
-import { UserModel } from 'src/users/entities/user.entity';
+import { ProviderType, UserModel } from 'src/users/entities/user.entity';
 import { UsersService } from 'src/users/users.service';
 import { AuthService } from './auth.service';
 import { loginUserDto } from './dto/login-user.dto';
@@ -143,7 +143,7 @@ describe('AuthService', () => {
     it('유효한 이메일과 provider로 유저를 인증한다.', async () => {
       const user: loginUserDto = {
         email: 'test@example.com',
-        provider: 'APPLE',
+        provider: ProviderType.APPLE,
       };
       const existUser = { ...user, userId: 1 } as UserModel;
       jest.spyOn(usersService, 'findUserByEmail').mockResolvedValue(existUser);
@@ -157,7 +157,7 @@ describe('AuthService', () => {
     it('존재하지 않는 이메일이면 UnauthorizedException을 발생시킨다.', async () => {
       const user: loginUserDto = {
         email: 'nonexistent@example.com',
-        provider: 'APPLE',
+        provider: ProviderType.APPLE,
       };
       jest.spyOn(usersService, 'findUserByEmail').mockResolvedValue(null);
 
@@ -169,7 +169,7 @@ describe('AuthService', () => {
     it('provider가 다르면 UnauthorizedException을 발생시킨다.', async () => {
       const user: loginUserDto = {
         email: 'test@example.com',
-        provider: 'GOOGLE',
+        provider: ProviderType.GOOGLE,
       };
       const existUser = { ...user, provider: 'APPLE', userId: 1 } as UserModel;
       jest.spyOn(usersService, 'findUserByEmail').mockResolvedValue(existUser);
@@ -184,7 +184,7 @@ describe('AuthService', () => {
     it('유효한 이메일과 provider로 로그인하고 토큰을 발급한다.', async () => {
       const user: loginUserDto = {
         email: 'test@example.com',
-        provider: 'APPLE',
+        provider: ProviderType.APPLE,
       };
       const existUser = { email: user.email, userId: 1 } as UserModel;
       jest
@@ -230,7 +230,7 @@ describe('AuthService', () => {
     it('유저를 등록하고 토큰을 발급한다.', async () => {
       const user: registerUserDto = {
         email: 'newuser@example.com',
-        provider: 'APPLE',
+        provider: ProviderType.APPLE,
         nickname: 'NewUser',
       };
       const newUser = { ...user, userId: 3 } as UserModel;

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -174,8 +174,8 @@ export class AuthService {
   signToken(user: Pick<UserModel, 'email' | 'id'>, tokenType: TokenType) {
     const payload = {
       email: user.email,
-      userID: user.id,
-      tokenType: tokenType,
+      userId: user.userId,
+      tokenType,
     };
     return this.jwtService.sign(payload, {
       secret: process.env.JWT_SECRET,

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -4,11 +4,11 @@ import axios from 'axios';
 import * as fs from 'fs';
 import * as jwt from 'jsonwebtoken';
 import * as querystring from 'querystring';
+import { CreateUserDto } from 'src/users/dto/create-user.dto';
 import { ProviderType, UserModel } from 'src/users/entities/user.entity';
 import { UsersService } from 'src/users/users.service';
 import { AuthUserDto } from './dto/auth-user.dto';
 import { loginUserDto } from './dto/login-user.dto';
-import { registerUserDto } from './dto/register-user.dto';
 
 type TokenType = 'access' | 'refresh';
 @Injectable()
@@ -171,7 +171,7 @@ export class AuthService {
    * @param tokenType 토큰 타입 (access/refresh)
    * @returns 토큰
    */
-  signToken(user: Pick<UserModel, 'email' | 'id'>, tokenType: TokenType) {
+  signToken(user: UserModel, tokenType: TokenType) {
     const payload = {
       email: user.email,
       userId: user.userId,
@@ -212,18 +212,6 @@ export class AuthService {
     }
     const accessToken = this.signToken({ ...payload }, 'access');
     return { accessToken };
-  }
-
-  /**
-   * user 정보를 통해 access,refresh 토큰을 발급 후 반환한다.
-   * @param user
-   * @returns { accessToken: string, refreshToken: string}
-   */
-  loginUser(user: Pick<UserModel, 'email' | 'userId'>) {
-    return {
-      accessToken: this.signToken(user, 'access'),
-      refreshToken: this.signToken(user, 'refresh'),
-    };
   }
 
   /**
@@ -277,11 +265,8 @@ export class AuthService {
    * @param user
    * @returns { accessToken: string, refreshToken: string}
    */
-  async registerUser(user: registerUserDto) {
-    const newUser = await this.usersService.createUser({
-      ...user,
-      providerId: 'USER_FOR_TEST',
-    });
+  async registerUser(user: CreateUserDto) {
+    const newUser = await this.usersService.createUser(user);
     return this.loginUser(newUser);
   }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { ProviderType, UserModel } from 'src/users/entities/user.entity';
-import { UsersService } from 'src/users/users.service';
-import * as querystring from 'querystring';
+import axios from 'axios';
 import * as fs from 'fs';
 import * as jwt from 'jsonwebtoken';
-import axios from 'axios';
+import * as querystring from 'querystring';
+import { ProviderType, UserModel } from 'src/users/entities/user.entity';
+import { UsersService } from 'src/users/users.service';
 import { AuthUserDto } from './dto/auth-user.dto';
 import { loginUserDto } from './dto/login-user.dto';
 import { registerUserDto } from './dto/register-user.dto';
@@ -171,8 +171,12 @@ export class AuthService {
    * @param tokenType 토큰 타입 (access/refresh)
    * @returns 토큰
    */
-  signToken(user: Pick<UserModel, 'email' | 'userId'>, tokenType: TokenType) {
-    const payload = { email: user.email, sub: user.userId };
+  signToken(user: Pick<UserModel, 'email' | 'id'>, tokenType: TokenType) {
+    const payload = {
+      email: user.email,
+      userID: user.id,
+      tokenType: tokenType,
+    };
     return this.jwtService.sign(payload, {
       secret: process.env.JWT_SECRET,
       expiresIn: tokenType === 'access' ? 300 : 3600,
@@ -210,17 +214,17 @@ export class AuthService {
     return { accessToken };
   }
 
-  // /**
-  //  * user 정보를 통해 access,refresh 토큰을 발급 후 반환한다.
-  //  * @param user
-  //  * @returns { accessToken: string, refreshToken: string}
-  //  */
-  // loginUser(user: Pick<UserModel, 'email' | 'id'>) {
-  //   return {
-  //     accessToken: this.signToken(user, 'access'),
-  //     refreshToken: this.signToken(user, 'refresh'),
-  //   };
-  // }
+  /**
+   * user 정보를 통해 access,refresh 토큰을 발급 후 반환한다.
+   * @param user
+   * @returns { accessToken: string, refreshToken: string}
+   */
+  loginUser(user: Pick<UserModel, 'email' | 'userId'>) {
+    return {
+      accessToken: this.signToken(user, 'access'),
+      refreshToken: this.signToken(user, 'refresh'),
+    };
+  }
 
   /**
    * 이메일과 provider를 통해 유저를 인증한다.

--- a/server/src/auth/dto/register-user.dto.ts
+++ b/server/src/auth/dto/register-user.dto.ts
@@ -13,4 +13,8 @@ export class registerUserDto {
   @IsString()
   @IsNotEmpty()
   fullName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  providerId: string;
 }

--- a/server/src/common/entity/base.entity.ts
+++ b/server/src/common/entity/base.entity.ts
@@ -1,12 +1,8 @@
-import {
-  CreateDateColumn,
-  PrimaryGeneratedColumn,
-  UpdateDateColumn,
-} from 'typeorm';
+import { CreateDateColumn, UpdateDateColumn } from 'typeorm';
 
 export abstract class BaseModel {
-  @PrimaryGeneratedColumn()
-  id: number;
+  // @PrimaryGeneratedColumn()
+  // id: number;
 
   @UpdateDateColumn()
   updatedAt: Date;

--- a/server/src/folders/entities/folder.entity.ts
+++ b/server/src/folders/entities/folder.entity.ts
@@ -1,10 +1,19 @@
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { BaseModel } from '../../common/entity/base.entity';
 import { UserModel } from '../../users/entities/user.entity';
 import { PrivateChecklistModel } from '../private-checklists/entities/private-checklist.entity';
 
 @Entity()
 export class FolderModel extends BaseModel {
+  @PrimaryGeneratedColumn()
+  folderId: number;
+
   @Column()
   title: string;
 

--- a/server/src/folders/folders.controller.ts
+++ b/server/src/folders/folders.controller.ts
@@ -1,15 +1,15 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Post,
   Put,
 } from '@nestjs/common';
-import { FoldersService } from './folders.service';
 import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
+import { FoldersService } from './folders.service';
 
 @Controller('folders')
 export class FoldersController {
@@ -17,28 +17,31 @@ export class FoldersController {
 
   @Post()
   postFolder(@Body() createFolderDto: CreateFolderDto) {
-    const uId = 1;
-    return this.foldersService.createFolder(uId, createFolderDto);
+    const userId: number = 1;
+    return this.foldersService.createFolder(userId, createFolderDto);
   }
 
   @Get()
   getFolders() {
-    const uId = 1;
-    return this.foldersService.findAllFolders(uId);
+    const userId: number = 1;
+    return this.foldersService.findAllFolders(userId);
   }
 
-  @Get(':id')
-  getFolder(@Param('id') id: number) {
-    return this.foldersService.findFolderById(id);
+  @Get(':forderId')
+  getFolder(@Param('forderId') forderId: number) {
+    return this.foldersService.findFolderById(forderId);
   }
 
-  @Put(':id')
-  putFolder(@Param('id') id: number, @Body() updateFolderDto: UpdateFolderDto) {
-    return this.foldersService.updateFolder(id, updateFolderDto);
+  @Put(':forderId')
+  putFolder(
+    @Param('forderId') forderId: number,
+    @Body() updateFolderDto: UpdateFolderDto,
+  ) {
+    return this.foldersService.updateFolder(forderId, updateFolderDto);
   }
 
-  @Delete(':id')
-  deleteFolder(@Param('id') id: number) {
-    return this.foldersService.removeFolder(id);
+  @Delete(':forderId')
+  deleteFolder(@Param('forderId') forderId: number) {
+    return this.foldersService.removeFolder(forderId);
   }
 }

--- a/server/src/folders/folders.service.spec.ts
+++ b/server/src/folders/folders.service.spec.ts
@@ -1,13 +1,13 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { FoldersService } from './folders.service';
-import { FolderModel } from './entities/folder.entity';
-import { Repository } from 'typeorm';
 import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserModel } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
 import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
-import { UsersService } from '../users/users.service';
-import { UserModel } from '../users/entities/user.entity';
+import { FolderModel } from './entities/folder.entity';
+import { FoldersService } from './folders.service';
 
 type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
 
@@ -63,7 +63,7 @@ describe('FoldersService', () => {
     };
     mockFoldersRepository.create.mockReturnValue(expectedFolderObject);
     mockFoldersRepository.save.mockResolvedValue({
-      id: 1,
+      folderId: 1,
       ...expectedFolderObject,
     });
 
@@ -78,7 +78,7 @@ describe('FoldersService', () => {
     expect(mockFoldersRepository.save).toHaveBeenCalledWith(
       expectedFolderObject,
     ); // 수정된 부분
-    expect(result).toEqual({ id: 1, ...expectedFolderObject });
+    expect(result).toEqual({ folderId: 1, ...expectedFolderObject });
   });
 
   it('service.createFolder(createFolderDto) : 이미 존재하는 폴더명일 경우 BadRequestException을 던진다.', async () => {
@@ -106,8 +106,8 @@ describe('FoldersService', () => {
 
   it('service.findAllFolders() : 모든 폴더를 찾는다.', async () => {
     const mockFolders = [
-      { id: 1, email: 'test@example.com', nickname: 'TestFolder' },
-      { id: 2, email: 'test2@example.com', nickname: 'TestFolder2' },
+      { folderId: 1, email: 'test@example.com', nickname: 'TestFolder' },
+      { folderId: 2, email: 'test2@example.com', nickname: 'TestFolder2' },
     ];
     mockFoldersRepository.find.mockResolvedValue(mockFolders);
 
@@ -117,20 +117,20 @@ describe('FoldersService', () => {
     expect(result).toEqual(mockFolders);
   });
 
-  it('service.findFolderById(id) : id에 해당하는 폴더를 찾는다.', async () => {
-    const folder = { id: 1, title: 'blackpink in your area' };
+  it('service.findFolderById(id) : folderId에 해당하는 폴더를 찾는다.', async () => {
+    const folder = { folderId: 1, title: 'blackpink in your area' };
     mockFoldersRepository.findOne.mockResolvedValue(folder);
 
     const result = await service.findFolderById(1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { folderId: 1 },
       relations: ['owner'],
     });
     expect(result).toEqual(folder);
   });
 
-  it('service.findFolderById(id) : 존재하지 않는 폴더명일 경우 BadRequestException을 던진다.', async () => {
+  it('service.findFolderById(folderId) : 존재하지 않는 폴더명일 경우 BadRequestException을 던진다.', async () => {
     mockFoldersRepository.findOne.mockResolvedValue(null);
 
     await expect(service.findFolderById(1)).rejects.toThrow(
@@ -138,12 +138,12 @@ describe('FoldersService', () => {
     );
   });
 
-  it('service.updateFolder(id, updateFolderDto) : id에 해당하는 폴더를 업데이트한다.', async () => {
+  it('service.updateFolder(folderId, updateFolderDto) : folderId에 해당하는 폴더를 업데이트한다.', async () => {
     const updateFolderDto: UpdateFolderDto = {
       title: 'newJeans in your area',
     };
     const existingFolder = {
-      id: 1,
+      folderId: 1,
       title: 'blackpink in your area',
     };
     mockFoldersRepository.findOne.mockResolvedValue(existingFolder);
@@ -155,7 +155,7 @@ describe('FoldersService', () => {
     const result = await service.updateFolder(1, updateFolderDto);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { folderId: 1 },
       relations: ['owner'],
     });
     expect(mockFoldersRepository.save).toHaveBeenCalledWith({
@@ -165,7 +165,7 @@ describe('FoldersService', () => {
     expect(result.title).toEqual('newJeans in your area');
   });
 
-  it('service.updateFolder(id, updateFolderDto) : 존재하지 않는 폴더 ID에 대한 처리를 검증한다.', async () => {
+  it('service.updateFolder(folderId, updateFolderDto) : 존재하지 않는 폴더 ID에 대한 처리를 검증한다.', async () => {
     const updateFolderDto: UpdateFolderDto = { title: 'UpdatedFolder' };
     mockFoldersRepository.findOne.mockResolvedValueOnce(null); // 폴더가 존재하지 않는다고 가정
 
@@ -174,22 +174,22 @@ describe('FoldersService', () => {
     );
   });
 
-  it('service.removeFolder(id) : id에 해당하는 폴더를 삭제한다.', async () => {
-    const folder = { id: 1, title: 'blackpink in your area' };
+  it('service.removeFolder(folderId) : folderId에 해당하는 폴더를 삭제한다.', async () => {
+    const folder = { folderId: 1, title: 'blackpink in your area' };
     mockFoldersRepository.findOne.mockResolvedValue(folder);
     mockFoldersRepository.remove.mockResolvedValue(folder);
 
     const result = await service.removeFolder(1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { folderId: 1 },
       relations: ['owner'],
     });
     expect(mockFoldersRepository.remove).toHaveBeenCalledWith(folder);
     expect(result).toEqual({ message: '삭제되었습니다.' });
   });
 
-  it('service.removeFolder(id) : 존재하지 않는 폴더 ID에 대한 처리를 검증한다.', async () => {
+  it('service.removeFolder(folderId) : 존재하지 않는 폴더 ID에 대한 처리를 검증한다.', async () => {
     mockFoldersRepository.findOne.mockResolvedValueOnce(null); // 폴더가 존재하지 않는다고 가정
 
     await expect(service.removeFolder(9999)).rejects.toThrow(

--- a/server/src/folders/folders.service.ts
+++ b/server/src/folders/folders.service.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { CreateFolderDto } from './dto/create-folder.dto';
-import { UpdateFolderDto } from './dto/update-folder.dto';
-import { FolderModel } from './entities/folder.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UsersService } from '../users/users.service';
+import { CreateFolderDto } from './dto/create-folder.dto';
+import { UpdateFolderDto } from './dto/update-folder.dto';
+import { FolderModel } from './entities/folder.entity';
 
 @Injectable()
 export class FoldersService {
@@ -13,8 +13,8 @@ export class FoldersService {
     private readonly folderRepository: Repository<FolderModel>,
     private readonly usersService: UsersService,
   ) {}
-  async createFolder(uId, dto: CreateFolderDto) {
-    const owner = await this.usersService.findUserById(uId);
+  async createFolder(userId: number, dto: CreateFolderDto) {
+    const owner = await this.usersService.findUserById(userId);
     const folderObject = this.folderRepository.create({
       ...dto,
       owner,
@@ -31,17 +31,17 @@ export class FoldersService {
     return newFolder;
   }
 
-  async findAllFolders(uId) {
+  async findAllFolders(userId: number) {
     const folders = await this.folderRepository.find({
-      where: { owner: { id: uId } },
+      where: { owner: { userId: userId } },
       relations: ['owner'],
     });
     return folders;
   }
 
-  async findFolderById(id: number) {
+  async findFolderById(folderId: number) {
     const folder = await this.folderRepository.findOne({
-      where: { id },
+      where: { folderId },
       relations: ['owner'],
     });
     if (!folder) {
@@ -50,8 +50,8 @@ export class FoldersService {
     return folder;
   }
 
-  async updateFolder(id: number, dto: UpdateFolderDto) {
-    const folder = await this.findFolderById(id);
+  async updateFolder(folderId: number, dto: UpdateFolderDto) {
+    const folder = await this.findFolderById(folderId);
     const updatedFolder = await this.folderRepository.save({
       ...folder,
       ...dto,
@@ -59,8 +59,8 @@ export class FoldersService {
     return updatedFolder;
   }
 
-  async removeFolder(id: number) {
-    const folder = await this.findFolderById(id);
+  async removeFolder(folderId: number) {
+    const folder = await this.findFolderById(folderId);
     await this.folderRepository.remove(folder);
     return { message: '삭제되었습니다.' };
   }

--- a/server/src/folders/private-checklists/entities/private-checklist.entity.ts
+++ b/server/src/folders/private-checklists/entities/private-checklist.entity.ts
@@ -1,10 +1,13 @@
-import { Entity, ManyToOne } from 'typeorm';
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { ChecklistModel } from '../../../common/entity/checklist.entity';
 import { UserModel } from '../../../users/entities/user.entity';
 import { FolderModel } from '../../entities/folder.entity';
 
 @Entity()
 export class PrivateChecklistModel extends ChecklistModel {
+  @PrimaryGeneratedColumn()
+  privateChecklistId: number;
+
   @ManyToOne(() => UserModel, (user) => user.privateChecklists, {
     nullable: false,
   })

--- a/server/src/folders/private-checklists/private-checklists.controller.ts
+++ b/server/src/folders/private-checklists/private-checklists.controller.ts
@@ -1,16 +1,15 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Post,
   Put,
 } from '@nestjs/common';
-import { PrivateChecklistsService } from './private-checklists.service';
 import { CreatePrivateChecklistDto } from './dto/create-private-checklist.dto';
 import { UpdatePrivateChecklistDto } from './dto/update-private-checklist.dto';
+import { PrivateChecklistsService } from './private-checklists.service';
 
 @Controller('folders/:folderId/checklists')
 export class PrivateChecklistsController {
@@ -18,60 +17,65 @@ export class PrivateChecklistsController {
 
   /**
    * @description userId와 folderId와 title을 통해 해당 folder에 새로운 checklist를 생성합니다.
-   * @param {number} fid
+   * @param {number} folderId
    * @param {CreatePrivateChecklistDto} dto
    * @returns {Promise<PrivateChecklistModel>}
    */
   @Post()
   postPrivateChecklist(
-    @Param('folderId') fid: number,
+    @Param('folderId') folderId: number,
     @Body() dto: CreatePrivateChecklistDto,
   ) {
-    const uId = 1;
-    return this.checklistsService.createPrivateChecklist(uId, fid, dto);
+    const userId: number = 1;
+    return this.checklistsService.createPrivateChecklist(userId, folderId, dto);
   }
 
   /**
    * @description folderId를 통해 해당 folder의 모든 checklist를 조회합니다.
-   * @param {number} fid
+   * @param {number} folderId
    * @returns {Promise<PrivateChecklistModel[]>}
    */
   @Get()
-  getAllPrivateChecklists(@Param('folderId') fid: number) {
-    return this.checklistsService.findAllPrivateChecklists(fid);
+  getAllPrivateChecklists(@Param('folderId') folderId: number) {
+    return this.checklistsService.findAllPrivateChecklists(folderId);
   }
 
   /**
    * @description checklistId를 통해 해당 checklist를 조회합니다.
-   * @param {number} cid
+   * @param {number} privateChecklistId
    * @returns {Promise<PrivateChecklistModel>}
    */
-  @Get(':checklistId')
-  getPrivateChecklist(@Param('checklistId') cid: number) {
-    return this.checklistsService.findPrivateChecklistById(cid);
+  @Get(':privateChecklistId')
+  getPrivateChecklist(@Param('privateChecklistId') privateChecklistId: number) {
+    return this.checklistsService.findPrivateChecklistById(privateChecklistId);
   }
 
   /**
    * @description checklistId를 통해 해당 checklist의 title을 수정합니다.
-   * @param {number} cid
+   * @param {number} privateChecklistId
    * @param {UpdatePrivateChecklistDto} dto
    * @returns {Promise<PrivateChecklistModel>}
    */
-  @Put(':checklistId')
+  @Put(':privateChecklistId')
   putPrivateChecklist(
-    @Param('checklistId') cid: number,
+    @Param('privateChecklistId') privateChecklistId: number,
     @Body() dto: UpdatePrivateChecklistDto,
   ) {
-    return this.checklistsService.updatePrivateChecklist(cid, dto);
+    return this.checklistsService.updatePrivateChecklist(
+      privateChecklistId,
+      dto,
+    );
   }
 
   /**
    * @description checklistId를 통해 해당 checklist를 삭제합니다.
-   * @param {number} cid
+   * @param {number} privateChecklistId
    * @returns {Promise<message:string>}
    */
-  @Delete(':checklistId')
-  deletePrivateChecklist(@Param('checklistId') cid: number) {
-    return this.checklistsService.removePrivateChecklist(cid);
+  @Delete(':privateChecklistId')
+  deletePrivateChecklist(
+    @Param('privateChecklistId') privateChecklistId: number,
+  ) {
+    return this.checklistsService.removePrivateChecklist(privateChecklistId);
   }
 }

--- a/server/src/folders/private-checklists/private-checklists.service.spec.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.spec.ts
@@ -106,24 +106,24 @@ describe('PrivateChecklistsService', () => {
     const result = await service.findAllPrivateChecklists(1);
 
     expect(mockChecklistRepository.find).toHaveBeenCalledWith({
-      where: { folder: { id: 1 } },
+      where: { folder: { folderId: 1 } },
     });
     expect(result).toEqual(checklists);
   });
 
-  it('service.findPrivateChecklistById(id) : id에 해당하는 체크리스트를 찾는다.', async () => {
+  it('service.findPrivateChecklistById(privateChecklistId) : privateChecklistId에 해당하는 체크리스트를 찾는다.', async () => {
     const checklist = new PrivateChecklistModel();
     mockChecklistRepository.findOne.mockResolvedValue(checklist);
 
     const result = await service.findPrivateChecklistById(1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { privateChecklistId: 1 },
     });
     expect(result).toEqual(checklist);
   });
 
-  it('service.findPrivateChecklistById(id) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.a', async () => {
+  it('service.findPrivateChecklistById(privateChecklistId) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
     await expect(service.findPrivateChecklistById(1)).rejects.toThrow(
@@ -131,7 +131,7 @@ describe('PrivateChecklistsService', () => {
     );
   });
 
-  it('service.updatePrivateChecklist(id, updateDto) : 체크리스트를 업데이트한다.', async () => {
+  it('service.updatePrivateChecklist(privateChecklistId, updateDto) : 체크리스트를 업데이트한다.', async () => {
     const updateDto = new UpdatePrivateChecklistDto();
     const existingChecklist = new PrivateChecklistModel();
     mockChecklistRepository.findOne.mockResolvedValue(existingChecklist);
@@ -143,7 +143,7 @@ describe('PrivateChecklistsService', () => {
     const result = await service.updatePrivateChecklist(1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { privateChecklistId: 1 },
     });
     expect(mockChecklistRepository.save).toHaveBeenCalledWith({
       ...existingChecklist,
@@ -152,7 +152,7 @@ describe('PrivateChecklistsService', () => {
     expect(result).toEqual({ ...existingChecklist, ...updateDto });
   });
 
-  it('service.updatePrivateChecklist(id, updateDto) : title만 업데이트한다.', async () => {
+  it('service.updatePrivateChecklist(privateChecklistId, updateDto) : title만 업데이트한다.', async () => {
     const updateDto = new UpdatePrivateChecklistDto();
     updateDto.title = 'Updated Title';
     const existingChecklist = new PrivateChecklistModel();
@@ -167,7 +167,7 @@ describe('PrivateChecklistsService', () => {
     const result = await service.updatePrivateChecklist(1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { privateChecklistId: 1 },
     });
     expect(mockChecklistRepository.save).toHaveBeenCalledWith({
       ...existingChecklist,
@@ -176,7 +176,7 @@ describe('PrivateChecklistsService', () => {
     expect(result.title).toEqual(updateDto.title); // 결과의 title이 업데이트된 title과 일치하는지 확인
   });
 
-  it('service.updatePrivateChecklist(id, updateDto) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
+  it('service.updatePrivateChecklist(privateChecklistId, updateDto) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
     const updateDto = new UpdatePrivateChecklistDto();
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
@@ -185,20 +185,20 @@ describe('PrivateChecklistsService', () => {
     );
   });
 
-  it('service.removePrivateChecklist(id) : 체크리스트를 삭제한다.', async () => {
+  it('service.removePrivateChecklist(privateChecklistId) : 체크리스트를 삭제한다.', async () => {
     const checklist = new PrivateChecklistModel();
     mockChecklistRepository.findOne.mockResolvedValue(checklist);
 
     const result = await service.removePrivateChecklist(1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { privateChecklistId: 1 },
     });
     expect(mockChecklistRepository.remove).toHaveBeenCalledWith(checklist);
     expect(result).toEqual({ message: '삭제되었습니다.' });
   });
 
-  it('service.removePrivateChecklist(id) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
+  it('service.removePrivateChecklist(privateChecklistId) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
     await expect(service.removePrivateChecklist(1)).rejects.toThrow(

--- a/server/src/folders/private-checklists/private-checklists.service.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.ts
@@ -17,14 +17,14 @@ export class PrivateChecklistsService {
   ) {}
 
   async createPrivateChecklist(
-    uid: number,
-    fid: number,
+    userId: number,
+    folderId: number,
     dto: CreatePrivateChecklistDto,
   ) {
     // 1. folderId를 통해 해당 folder가 존재하는지 확인합니다.
     // userId를 통해 user entity를 가져옵니다.
-    const folder = await this.foldersService.findFolderById(fid);
-    const user = await this.usersService.findUserById(uid);
+    const folder = await this.foldersService.findFolderById(folderId);
+    const user = await this.usersService.findUserById(userId);
 
     // 3. 새로운 checklist를 생성합니다.
     const newChecklist = this.repository.create({
@@ -37,16 +37,16 @@ export class PrivateChecklistsService {
     return this.repository.save(newChecklist);
   }
 
-  async findAllPrivateChecklists(fid: number) {
+  async findAllPrivateChecklists(folderId: number) {
     const checklists = await this.repository.find({
-      where: { folder: { id: fid } },
+      where: { folder: { folderId } },
     });
     return checklists;
   }
 
-  async findPrivateChecklistById(id: number) {
+  async findPrivateChecklistById(privateChecklistId: number) {
     const checklist = await this.repository.findOne({
-      where: { id },
+      where: { privateChecklistId },
     });
     if (!checklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');
@@ -54,9 +54,12 @@ export class PrivateChecklistsService {
     return checklist;
   }
 
-  async updatePrivateChecklist(id: number, dto: UpdatePrivateChecklistDto) {
+  async updatePrivateChecklist(
+    privateChecklistId: number,
+    dto: UpdatePrivateChecklistDto,
+  ) {
     const { title, folderId } = dto;
-    const checklist = await this.findPrivateChecklistById(id);
+    const checklist = await this.findPrivateChecklistById(privateChecklistId);
     if (!checklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');
     }
@@ -74,8 +77,8 @@ export class PrivateChecklistsService {
     return newChecklist;
   }
 
-  async removePrivateChecklist(id: number) {
-    const checklist = await this.findPrivateChecklistById(id);
+  async removePrivateChecklist(privateChecklistId: number) {
+    const checklist = await this.findPrivateChecklistById(privateChecklistId);
 
     // soft-delete 방식으로 수정필요
     await this.repository.remove(checklist);

--- a/server/src/shared-checklists/entities/shared-checklist.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist.entity.ts
@@ -1,10 +1,11 @@
-import { Entity, ManyToMany } from 'typeorm';
+import { Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { ChecklistModel } from '../../common/entity/checklist.entity';
 import { UserModel } from '../../users/entities/user.entity';
-import { JoinTable } from 'typeorm';
 
 @Entity()
 export class SharedChecklistModel extends ChecklistModel {
+  @PrimaryGeneratedColumn()
+  sharedChecklistId: number;
   @ManyToMany(() => UserModel, (user) => user.sharedChecklists, {
     nullable: false,
   })

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { SharedChecklistModel } from './entities/shared-checklist.entity';
-import { CreateSharedChecklistDto } from './dto/create-shared-checklist.dto';
 import { UsersService } from '../users/users.service';
+import { CreateSharedChecklistDto } from './dto/create-shared-checklist.dto';
 import { UpdateSharedChecklistDto } from './dto/update-shared-checklist.dto';
+import { SharedChecklistModel } from './entities/shared-checklist.entity';
 
 @Injectable()
 export class SharedChecklistsService {
@@ -45,9 +45,9 @@ export class SharedChecklistsService {
     return checklists;
   }
 
-  async findSharedChecklistById(id: number) {
+  async findSharedChecklistById(sharedChecklistId: number) {
     const checklist = await this.repository.findOne({
-      where: { id },
+      where: { sharedChecklistId },
     });
     if (!checklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');

--- a/server/src/users/dto/create-user.dto.ts
+++ b/server/src/users/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
 import { ProviderType } from '../entities/user.entity';
 
 export class CreateUserDto {
@@ -6,7 +6,7 @@ export class CreateUserDto {
   @IsNotEmpty()
   providerId: string;
 
-  @IsString()
+  @IsEnum(ProviderType)
   @IsNotEmpty()
   provider: ProviderType;
 

--- a/server/src/users/dto/create-user.dto.ts
+++ b/server/src/users/dto/create-user.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 import { ProviderType } from '../entities/user.entity';
 
 export class CreateUserDto {
@@ -17,4 +23,8 @@ export class CreateUserDto {
   @IsString()
   @IsNotEmpty()
   fullName: string;
+
+  @IsString()
+  @IsOptional()
+  nickname?: string;
 }

--- a/server/src/users/dto/update-user.dto.ts
+++ b/server/src/users/dto/update-user.dto.ts
@@ -1,7 +1,8 @@
-import { PickType } from '@nestjs/mapped-types';
+import { PartialType, PickType } from '@nestjs/mapped-types';
 import { CreateUserDto } from './create-user.dto';
-
-export class UpdateUserDto extends PickType(CreateUserDto, [
+class PartialCreateUserDto extends PickType(CreateUserDto, [
   'email',
   'fullName',
 ]) {}
+
+export class UpdateUserDto extends PartialType(PartialCreateUserDto) {}

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -30,7 +30,7 @@ export class UsersController {
     return this.usersService.findUserById(userId);
   }
 
-  @Put(':id')
+  @Put(':userId')
   putUser(
     @Param('userId') userId: number,
     @Body() updateUserDto: UpdateUserDto,
@@ -38,7 +38,7 @@ export class UsersController {
     return this.usersService.updateUser(userId, updateUserDto);
   }
 
-  @Delete(':id')
+  @Delete(':userId')
   deleteUser(@Param('userId') userId: number) {
     return this.usersService.removeUser(userId);
   }

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -1,16 +1,15 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Patch,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Post,
   Put,
 } from '@nestjs/common';
-import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UsersService } from './users.service';
 
 @Controller('users')
 export class UsersController {
@@ -26,18 +25,21 @@ export class UsersController {
     return this.usersService.findAllUsers();
   }
 
-  @Get(':id')
-  getUser(@Param('id') id: string) {
-    return this.usersService.findUserById(+id);
+  @Get(':userId')
+  getUser(@Param('userId') userId: number) {
+    return this.usersService.findUserById(userId);
   }
 
   @Put(':id')
-  putUser(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.updateUser(+id, updateUserDto);
+  putUser(
+    @Param('userId') userId: number,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    return this.usersService.updateUser(userId, updateUserDto);
   }
 
   @Delete(':id')
-  deleteUser(@Param('id') id: string) {
-    return this.usersService.removeUser(+id);
+  deleteUser(@Param('userId') userId: number) {
+    return this.usersService.removeUser(userId);
   }
 }

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -39,7 +39,8 @@ describe('UsersService', () => {
   it('service.createUser(createUserDto) : 새로운 유저를 생성한다.', async () => {
     const createUserDto: CreateUserDto = {
       email: 'test@example.com',
-      nickname: 'TestUser',
+      fullName: 'TestUser',
+      providerId: '1234567890',
       provider: ProviderType.APPLE, // Enum 멤버 사용
     };
     mockUsersRepository.exist.mockResolvedValue(false);
@@ -59,7 +60,8 @@ describe('UsersService', () => {
   it('service.createUser(createUserDto) : 이미 존재하는 이메일일 경우 BadRequestException을 던진다.', async () => {
     const createUserDto: CreateUserDto = {
       email: 'test@example.com',
-      nickname: 'TestUser',
+      fullName: 'TestUser',
+      providerId: '1234567890',
       provider: ProviderType.APPLE, // Enum 멤버 사용
     };
     mockUsersRepository.exist.mockResolvedValue(true);
@@ -101,11 +103,11 @@ describe('UsersService', () => {
   });
 
   it('service.updateUser(userId, updateUserDto) : userId에 해당하는 유저를 업데이트한다.', async () => {
-    const updateUserDto: UpdateUserDto = { nickname: 'UpdatedUser' };
+    const updateUserDto: UpdateUserDto = { fullName: 'UpdatedUser' };
     const existingUser = {
       userId: 1,
       email: 'test@example.com',
-      nickname: 'TestUser',
+      fullName: 'TestUser',
     };
     mockUsersRepository.findOne.mockResolvedValue(existingUser);
     mockUsersRepository.save.mockResolvedValue({
@@ -122,11 +124,11 @@ describe('UsersService', () => {
       ...existingUser,
       ...updateUserDto,
     });
-    expect(result.nickname).toEqual('UpdatedUser');
+    expect(result.fullName).toEqual('UpdatedUser');
   });
 
   it('service.updateUser(userId, updateUserDto) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
-    const updateUserDto: UpdateUserDto = { nickname: 'UpdatedUser' };
+    const updateUserDto: UpdateUserDto = { fullName: 'UpdatedUser' };
     mockUsersRepository.findOne.mockResolvedValue(null);
 
     await expect(service.updateUser(1, updateUserDto)).rejects.toThrow(

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -40,6 +40,7 @@ describe('UsersService', () => {
     const createUserDto: CreateUserDto = {
       email: 'test@example.com',
       fullName: 'TestUser',
+      nickname: 'TestUser',
       providerId: '1234567890',
       provider: ProviderType.APPLE, // Enum 멤버 사용
     };
@@ -108,6 +109,7 @@ describe('UsersService', () => {
       userId: 1,
       email: 'test@example.com',
       fullName: 'TestUser',
+      nickname: 'TestUser',
     };
     mockUsersRepository.findOne.mockResolvedValue(existingUser);
     mockUsersRepository.save.mockResolvedValue({

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { UserModel } from './entities/user.entity';
+import { ProviderType, UserModel } from './entities/user.entity';
 import { UsersService } from './users.service';
 
 type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
@@ -40,7 +40,7 @@ describe('UsersService', () => {
     const createUserDto: CreateUserDto = {
       email: 'test@example.com',
       nickname: 'TestUser',
-      provider: 'APPLE',
+      provider: ProviderType.APPLE, // Enum 멤버 사용
     };
     mockUsersRepository.exist.mockResolvedValue(false);
     mockUsersRepository.create.mockReturnValue(createUserDto);
@@ -60,7 +60,7 @@ describe('UsersService', () => {
     const createUserDto: CreateUserDto = {
       email: 'test@example.com',
       nickname: 'TestUser',
-      provider: 'APPLE',
+      provider: ProviderType.APPLE, // Enum 멤버 사용
     };
     mockUsersRepository.exist.mockResolvedValue(true);
 

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -44,7 +44,7 @@ describe('UsersService', () => {
     };
     mockUsersRepository.exist.mockResolvedValue(false);
     mockUsersRepository.create.mockReturnValue(createUserDto);
-    mockUsersRepository.save.mockResolvedValue({ id: 1, ...createUserDto });
+    mockUsersRepository.save.mockResolvedValue({ userId: 1, ...createUserDto });
 
     const result = await service.createUser(createUserDto);
 
@@ -53,7 +53,7 @@ describe('UsersService', () => {
     });
     expect(mockUsersRepository.create).toHaveBeenCalledWith(createUserDto);
     expect(mockUsersRepository.save).toHaveBeenCalledWith(createUserDto);
-    expect(result).toEqual({ id: 1, ...createUserDto });
+    expect(result).toEqual({ userId: 1, ...createUserDto });
   });
 
   it('service.createUser(createUserDto) : 이미 존재하는 이메일일 경우 BadRequestException을 던진다.', async () => {
@@ -71,8 +71,8 @@ describe('UsersService', () => {
 
   it('service.findAllUsers() : 모든 유저를 찾는다.', async () => {
     const mockUsers = [
-      { id: 1, email: 'test@example.com', nickname: 'TestUser' },
-      { id: 2, email: 'test2@example.com', nickname: 'TestUser2' },
+      { userId: 1, email: 'test@example.com', nickname: 'TestUser' },
+      { userId: 2, email: 'test2@example.com', nickname: 'TestUser2' },
     ];
     mockUsersRepository.find.mockResolvedValue(mockUsers);
 
@@ -82,28 +82,28 @@ describe('UsersService', () => {
     expect(result).toEqual(mockUsers);
   });
 
-  it('service.findUserById(id) : id에 해당하는 유저를 찾는다.', async () => {
-    const user = { id: 1, email: 'test@example.com', nickname: 'TestUser' };
+  it('service.findUserById(userId) : userId에 해당하는 유저를 찾는다.', async () => {
+    const user = { userId: 1, email: 'test@example.com', nickname: 'TestUser' };
     mockUsersRepository.findOne.mockResolvedValue(user);
 
     const result = await service.findUserById(1);
 
     expect(mockUsersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { userId: 1 },
     });
     expect(result).toEqual(user);
   });
 
-  it('service.findUserById(id) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
+  it('service.findUserById(userId) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
     mockUsersRepository.findOne.mockResolvedValue(null);
 
     await expect(service.findUserById(1)).rejects.toThrow(BadRequestException);
   });
 
-  it('service.updateUser(id, updateUserDto) : id에 해당하는 유저를 업데이트한다.', async () => {
+  it('service.updateUser(userId, updateUserDto) : userId에 해당하는 유저를 업데이트한다.', async () => {
     const updateUserDto: UpdateUserDto = { nickname: 'UpdatedUser' };
     const existingUser = {
-      id: 1,
+      userId: 1,
       email: 'test@example.com',
       nickname: 'TestUser',
     };
@@ -116,7 +116,7 @@ describe('UsersService', () => {
     const result = await service.updateUser(1, updateUserDto);
 
     expect(mockUsersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { userId: 1 },
     });
     expect(mockUsersRepository.save).toHaveBeenCalledWith({
       ...existingUser,
@@ -125,7 +125,7 @@ describe('UsersService', () => {
     expect(result.nickname).toEqual('UpdatedUser');
   });
 
-  it('service.updateUser(id, updateUserDto) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
+  it('service.updateUser(userId, updateUserDto) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
     const updateUserDto: UpdateUserDto = { nickname: 'UpdatedUser' };
     mockUsersRepository.findOne.mockResolvedValue(null);
 
@@ -134,21 +134,21 @@ describe('UsersService', () => {
     );
   });
 
-  it('service.removeUser(id) : id에 해당하는 유저를 삭제한다.', async () => {
-    const user = { id: 1, email: 'test@example.com', nickname: 'TestUser' };
+  it('service.removeUser(userId) : userId에 해당하는 유저를 삭제한다.', async () => {
+    const user = { userId: 1, email: 'test@example.com', nickname: 'TestUser' };
     mockUsersRepository.findOne.mockResolvedValue(user);
     mockUsersRepository.remove.mockResolvedValue(user);
 
     const result = await service.removeUser(1);
 
     expect(mockUsersRepository.findOne).toHaveBeenCalledWith({
-      where: { id: 1 },
+      where: { userId: 1 },
     });
     expect(mockUsersRepository.remove).toHaveBeenCalledWith(user);
     expect(result).toEqual({ message: '삭제되었습니다.' });
   });
 
-  it('service.removeUser(id) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
+  it('service.removeUser(userId) : 존재하지 않는 유저일 경우 BadRequestException을 던진다.', async () => {
     mockUsersRepository.findOne.mockResolvedValue(null);
     await expect(service.removeUser(1)).rejects.toThrow(BadRequestException);
   });

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -46,8 +46,8 @@ export class UsersService {
     return users;
   }
 
-  async findUserById(id: number) {
-    const user = await this.usersRepository.findOne({ where: { id } });
+  async findUserById(userId: number) {
+    const user = await this.usersRepository.findOne({ where: { userId } });
     if (!user) {
       throw new BadRequestException('존재하지 않는 유저입니다.');
     }
@@ -76,8 +76,22 @@ export class UsersService {
     return newUser;
   }
 
-  async updateUser(id: number, updateUserDto: UpdateUserDto) {
-    const user = await this.findUserById(id);
+  async createUser(createUserDto: CreateUserDto) {
+    const userObject = this.usersRepository.create(createUserDto);
+    const emailExists = await this.usersRepository.exist({
+      where: {
+        email: createUserDto.email,
+      },
+    });
+    if (emailExists) {
+      throw new BadRequestException('이미 존재하는 이메일입니다.');
+    }
+    const newUser = await this.usersRepository.save(userObject);
+    return newUser;
+  }
+
+  async updateUser(userId: number, updateUserDto: UpdateUserDto) {
+    const user = await this.findUserById(userId);
     const updatedUser = await this.usersRepository.save({
       ...user,
       ...updateUserDto,
@@ -85,8 +99,8 @@ export class UsersService {
     return updatedUser;
   }
 
-  async removeUser(id: number) {
-    const user = await this.findUserById(id);
+  async removeUser(userId: number) {
+    const user = await this.findUserById(userId);
     await this.usersRepository.remove(user);
     return { message: '삭제되었습니다.' };
   }

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -63,6 +63,9 @@ export class UsersService {
   }
 
   async createUser(createUserDto: CreateUserDto) {
+    if (!createUserDto.nickname) {
+      createUserDto.nickname = createUserDto.fullName;
+    }
     const userObject = this.usersRepository.create(createUserDto);
     const emailExists = await this.usersRepository.exist({
       where: {

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -32,8 +32,8 @@ export class UsersService {
     return newUser;
   }
 
-  async updateAppleUser(id: number, dto: UpdateUserDto) {
-    const user = await this.findUserById(id);
+  async updateAppleUser(userId: number, dto: UpdateUserDto) {
+    const user = await this.findUserById(userId);
     const updatedUser = await this.usersRepository.save({
       ...user,
       ...dto,
@@ -60,20 +60,6 @@ export class UsersService {
       throw new BadRequestException('존재하지 않는 유저입니다.');
     }
     return user;
-  }
-
-  async createUser(createUserDto: CreateUserDto) {
-    const userObject = this.usersRepository.create(createUserDto);
-    const emailExists = await this.usersRepository.exist({
-      where: {
-        email: createUserDto.email,
-      },
-    });
-    if (emailExists) {
-      throw new BadRequestException('이미 존재하는 이메일입니다.');
-    }
-    const newUser = await this.usersRepository.save(userObject);
-    return newUser;
   }
 
   async createUser(createUserDto: CreateUserDto) {


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #82 

## 고민과 해결 과정
- 원인
- <img width="594" alt="스크린샷 2023-11-25 오후 8 45 29" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/356118f7-efee-46df-a86e-73fec50fff95">
- 토큰에 담을 때 user.id를 userId로 담아서 보낸다. 그래서 토큰 정보를 재활용할 떄 user.id가 아닌 user.userId이기에 user.id가 undefind가 된다. 
- 해결방안
- 사실 payload의 {userId: user.id}를  {id: user.id}로 바꾸면 해결된다. 그러나 왜 이런 버그를 미리 발견하지 못했냐면 endity의 id를 단순히 id로 해서였다. 지금은 간단하게 해결했지만 추후에 이런 문제를 방지하고자 기존 endity의 id를 enditynameId로 전부 변경하였다. (id-> userId)


## 스크린샷
- 기존
- <img width="375" alt="스크린샷 2023-11-25 오후 8 42 38" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/e94a66ba-51da-43f7-93ee-1e7369d14faa">
- 변경 후
- <img width="405" alt="스크린샷 2023-11-25 오후 10 40 18" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/07d3406e-8b81-45f2-8e93-84572b160658">

## 테스트 결과(커버리지/테스트 결과)
- 테스트들들 잘 작동한다.
- <img width="816" alt="스크린샷 2023-11-25 오후 10 42 05" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/3626506c-bb2b-4a4b-8a12-9c1c8723d07f">
