### PR TITLE
[Server] apple oauth api 구현

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^3.0.1",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "@nestjs/platform-ws": "^10.2.10",
     "@nestjs/typeorm": "^10.0.0",
     "@nestjs/websockets": "^10.2.10",
+    "axios": "^1.6.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "nest-winston": "^1.9.4",

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -2,10 +2,21 @@ import { Body, Controller, Headers, Post } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { loginUserDto } from './dto/login-user.dto';
 import { registerUserDto } from './dto/register-user.dto';
+import { AuthUserDto } from './dto/auth-user.dto';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  /**
+   * Apple 로그인/등록을 처리한다.
+   * @param dto {AuthUserDto}
+   * @returns {accessToken, refreshToken}
+   */
+  @Post('apple/login')
+  async postAppleLogin(@Body() dto: AuthUserDto) {
+    return await this.authService.registerOrLoginWithApple(dto);
+  }
 
   /**
    * 이메일과 프로바이더를 통해 로그인한다. (개발자용)
@@ -20,7 +31,7 @@ export class AuthController {
   /**
    * refresh 토큰을 통해 access 토큰을 재발급한다.
    * @param rawToken
-   * @returns {accessToken}
+   * @returns {accessToken,refreshAccessToken}
    */
   @Post('token/access')
   postAccessToken(@Headers('authorization') rawToken: string) {

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,7 +1,12 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { UserModel } from 'src/users/entities/user.entity';
+import { ProviderType, UserModel } from 'src/users/entities/user.entity';
 import { UsersService } from 'src/users/users.service';
+import * as querystring from 'querystring';
+import * as fs from 'fs';
+import * as jwt from 'jsonwebtoken';
+import axios from 'axios';
+import { AuthUserDto } from './dto/auth-user.dto';
 import { loginUserDto } from './dto/login-user.dto';
 import { registerUserDto } from './dto/register-user.dto';
 
@@ -12,6 +17,112 @@ export class AuthService {
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
   ) {}
+  /**
+   * 애플 서버로부터 액세스 토큰과 리프레시 토큰을 받아옵니다.
+   * @param authorizeCode 클라이언트로부터 받은 애플 인증 코드
+   * @returns 애플로부터 받은 토큰들
+   */
+  async getAppleTokens(
+    authorizeCode: string,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    try {
+      // 클라이언트 시크릿 생성
+      const clientSecret = this.generateClientSecret();
+
+      // 애플 서버에 토큰 요청
+      const response = await axios.post(
+        'https://appleid.apple.com/auth/token',
+        querystring.stringify({
+          grant_type: 'authorization_code',
+          code: authorizeCode,
+          client_secret: clientSecret,
+          client_id: process.env.SUB,
+        }),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        },
+      );
+
+      // 애플이 발급해준 access_token과 refresh_token 반환
+      return {
+        accessToken: response.data.access_token,
+        refreshToken: response.data.refresh_token,
+      };
+    } catch (error) {
+      throw new UnauthorizedException(
+        '애플 인증 과정에서 오류가 발생했습니다.',
+      );
+    }
+  }
+
+  /**
+   * 클라이언트 시크릿을 생성합니다.
+   * @returns 생성된 클라이언트 시크릿
+   */
+  private generateClientSecret(): string {
+    const algorithm = process.env.ALG as jwt.Algorithm; // 타입 캐스팅
+    const keyid = process.env.KID;
+    const issuer = process.env.ISS;
+    const expiresIn = 15777000; // 6개월 (초 단위)
+    const audience = 'https://appleid.apple.com';
+    const subject = process.env.SUB;
+    const authKey = fs.readFileSync(process.env.AUTHKEY, 'utf8');
+
+    const signOptions: jwt.SignOptions = {
+      algorithm: algorithm,
+      keyid: keyid,
+      issuer: issuer,
+      audience: audience,
+      subject: subject,
+      expiresIn: expiresIn,
+    };
+
+    return jwt.sign({}, authKey, signOptions);
+  }
+
+  async registerOrLoginWithApple(
+    authUserDto: AuthUserDto,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const { authorizationCode, idToken, user: userDto } = authUserDto;
+    const decodedIdToken = jwt.verify(idToken, process.env.APPLE_PUBLIC_KEY);
+    if (!decodedIdToken || typeof decodedIdToken === 'string') {
+      throw new UnauthorizedException('애플 토큰 디코드 오류');
+    }
+
+    const fullName = `${userDto.name.firstName} ${userDto.name.lastName}`;
+    let user = await this.usersService.findUserByAppleId(decodedIdToken.sub);
+
+    if (!user) {
+      user = await this.usersService.createAppleUser({
+        providerId: decodedIdToken.sub,
+        provider: ProviderType.APPLE,
+        email: userDto.email,
+        fullName,
+      });
+    } else if (userDto) {
+      // entity가 존재하는데, user정보가 왔다면 업데이트
+      user = await this.usersService.updateAppleUser(user.userId, {
+        email: userDto.email,
+        fullName,
+      });
+    }
+
+    // 사용자에 대한 서비스의 JWT 토큰 생성
+    return this.loginUser(user);
+  }
+
+  /**
+   * 유저 정보를 통해 signToken()을 호출하여 access/refresh 토큰을 반환한다.
+   * @param {UserModel} user
+   * @returns {{accessToken: string, refreshToken: string}}
+   */
+
+  loginUser(user: UserModel): { accessToken: string; refreshToken: string } {
+    const accessToken = this.signToken(user, 'access');
+    const refreshToken = this.signToken(user, 'refresh');
+
+    return { accessToken, refreshToken };
+  }
 
   /**
    * 유저 정보를 통해 access/refresh 토큰을 발급한다.
@@ -19,12 +130,8 @@ export class AuthService {
    * @param tokenType 토큰 타입 (access/refresh)
    * @returns 토큰
    */
-  signToken(user: Pick<UserModel, 'email' | 'id'>, tokenType: TokenType) {
-    const payload = {
-      email: user.email,
-      userID: user.id,
-      tokenType: tokenType,
-    };
+  signToken(user: Pick<UserModel, 'email' | 'userId'>, tokenType: TokenType) {
+    const payload = { email: user.email, sub: user.userId };
     return this.jwtService.sign(payload, {
       secret: process.env.JWT_SECRET,
       expiresIn: tokenType === 'access' ? 300 : 3600,
@@ -62,17 +169,17 @@ export class AuthService {
     return { accessToken };
   }
 
-  /**
-   * user 정보를 통해 access,refresh 토큰을 발급 후 반환한다.
-   * @param user
-   * @returns { accessToken: string, refreshToken: string}
-   */
-  loginUser(user: Pick<UserModel, 'email' | 'id'>) {
-    return {
-      accessToken: this.signToken(user, 'access'),
-      refreshToken: this.signToken(user, 'refresh'),
-    };
-  }
+  // /**
+  //  * user 정보를 통해 access,refresh 토큰을 발급 후 반환한다.
+  //  * @param user
+  //  * @returns { accessToken: string, refreshToken: string}
+  //  */
+  // loginUser(user: Pick<UserModel, 'email' | 'id'>) {
+  //   return {
+  //     accessToken: this.signToken(user, 'access'),
+  //     refreshToken: this.signToken(user, 'refresh'),
+  //   };
+  // }
 
   /**
    * 이메일과 provider를 통해 유저를 인증한다.
@@ -126,7 +233,10 @@ export class AuthService {
    * @returns { accessToken: string, refreshToken: string}
    */
   async registerUser(user: registerUserDto) {
-    const newUser = await this.usersService.createUser(user);
+    const newUser = await this.usersService.createUser({
+      ...user,
+      providerId: 'USER_FOR_TEST',
+    });
     return this.loginUser(newUser);
   }
 }

--- a/server/src/auth/dto/auth-user.dto.ts
+++ b/server/src/auth/dto/auth-user.dto.ts
@@ -1,0 +1,42 @@
+import {
+  IsString,
+  IsEmail,
+  IsNotEmpty,
+  ValidateNested,
+  IsOptional,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+class NameDto {
+  @IsString()
+  @IsNotEmpty()
+  firstName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  lastName: string;
+}
+
+export class UserDto {
+  @IsEmail()
+  email: string;
+
+  @ValidateNested()
+  @Type(() => NameDto)
+  name: NameDto;
+}
+
+export class AuthUserDto {
+  @IsString()
+  @IsNotEmpty()
+  authorizationCode: string;
+
+  @IsString()
+  @IsNotEmpty()
+  idToken: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UserDto)
+  user?: UserDto;
+}

--- a/server/src/auth/dto/register-user.dto.ts
+++ b/server/src/auth/dto/register-user.dto.ts
@@ -12,5 +12,5 @@ export class registerUserDto {
 
   @IsString()
   @IsNotEmpty()
-  nickname: string;
+  fullName: string;
 }

--- a/server/src/users/dto/create-user.dto.ts
+++ b/server/src/users/dto/create-user.dto.ts
@@ -2,14 +2,19 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 import { ProviderType } from '../entities/user.entity';
 
 export class CreateUserDto {
-  @IsEmail()
-  email: string;
+  @IsString()
+  @IsNotEmpty()
+  providerId: string;
 
   @IsString()
   @IsNotEmpty()
   provider: ProviderType;
 
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
   @IsString()
   @IsNotEmpty()
-  nickname: string;
+  fullName: string;
 }

--- a/server/src/users/dto/update-user.dto.ts
+++ b/server/src/users/dto/update-user.dto.ts
@@ -1,4 +1,7 @@
 import { PickType } from '@nestjs/mapped-types';
 import { CreateUserDto } from './create-user.dto';
 
-export class UpdateUserDto extends PickType(CreateUserDto, ['nickname']) {}
+export class UpdateUserDto extends PickType(CreateUserDto, [
+  'email',
+  'fullName',
+]) {}

--- a/server/src/users/entities/user.entity.ts
+++ b/server/src/users/entities/user.entity.ts
@@ -1,21 +1,40 @@
 import { BaseModel } from 'src/common/entity/base.entity';
-import { Column, Entity, Generated, ManyToMany, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Generated,
+  ManyToMany,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { FolderModel } from '../../folders/entities/folder.entity';
 import { PrivateChecklistModel } from '../../folders/private-checklists/entities/private-checklist.entity';
 import { SharedChecklistModel } from '../../shared-checklists/entities/shared-checklist.entity';
 
-export type ProviderType = 'APPLE' | 'GOOGLE';
+export enum ProviderType {
+  APPLE = 'APPLE',
+  GOOGLE = 'GOOGLE',
+}
 @Entity()
 export class UserModel extends BaseModel {
+  @PrimaryGeneratedColumn()
+  userId: number;
+
   @Column({ unique: true })
   email: string;
 
   @Column()
-  @Generated('uuid') // 임시로 uuid를 생성해줌(원래는 provider의 고유 id를 받아와야함)
+  // @Generated('uuid') // 임시로 uuid를 생성해줌(원래는 provider의 고유 id를 받아와야함)
   providerId: string;
 
-  @Column()
+  @Column({
+    type: 'enum',
+    enum: ProviderType,
+  })
   provider: ProviderType;
+
+  @Column()
+  fullName: string;
 
   @Column()
   nickname: string;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -694,6 +694,11 @@
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
 
+"@nestjs/axios@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-3.0.1.tgz#b006f81dd54a49def92cfaf9a8970434567e75ce"
+  integrity sha512-VlOZhAGDmOoFdsmewn8AyClAdGpKXQQaY1+3PGB+g6ceurGIdTxZgRX3VXc1T6Zs60PedWjg3A82TDOB05mrzQ==
+
 "@nestjs/cli@^10.0.0":
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/@nestjs/cli/-/cli-10.2.1.tgz#a1d32c28e188f0fb4c3f54235c55745de4c6dd7f"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1549,6 +1549,15 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -2735,6 +2744,11 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 foreground-child@^3.1.0:
   version "3.1.1"
@@ -4596,6 +4610,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
Closed #81 
## 고민과 해결 과정

- 애플 OAuth 인증 플로우에서 클라이언트(예: 모바일 앱 또는 웹 애플리케이션)는 사용자가 애플 ID로 로그인한 후 받은 id_token과 authorization_code를 서버로 보낸다.

- 서버는 자체적으로 Client Secret을 생성한다. 애플 개발자 계정에서 제공받은 특정 키(.p8 파일)와 함께 서버의 개인 정보(알고리즘, 키 ID, 팀 ID 등)를 포함하여 생성한다.

-  생성된 Client Secret과 클라이언트로부터 받은 authorization_code를 사용하여 애플의 인증 서버에 액세스 토큰을 요청한다. 요청은 axios POST 요청으로 보낸다

- 서버는 애플의 JWKS(공개키 세트) 엔드포인트에서 공개키를 가져와 id_token의 유효성을 검증해서 사용자가 실제로 애플 ID를 통해 인증되었는지 확인하는 과정이다.

- 핵복잡하다

- dto, entity 수정

## 스크린샷
N/A
## 테스트 결과(커버리지/테스트 결과)
N/A