### PR TITLE
[Server] AccessTokenGuard 구현 및 적용

### DIFF
--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 
 @Module({
   imports: [JwtModule.register({}), UsersModule],
+  exports: [AuthService],
   controllers: [AuthController],
   providers: [AuthService],
 })

--- a/server/src/auth/guard/access-token.guard.ts
+++ b/server/src/auth/guard/access-token.guard.ts
@@ -6,33 +6,44 @@ import {
 } from '@nestjs/common';
 import { AuthService } from '../auth.service';
 
+/**
+ * 엑세스 토큰을 검증하는 Guard
+ * 엑세스 토큰이 없거나, 잘못된 경우 오류를 발생시킴
+ * 엑세스 토큰이 유효한 경우 요청 객체에 userId 필드를 추가함
+ */
 @Injectable()
 export class AccessTokenGuard implements CanActivate {
   constructor(private readonly authService: AuthService) {}
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
-
     const url = req.url;
 
-    // /auth 경로는 Guard를 적용하지 않음
+    // /auth 경로에 대한 요청은 Guard를 적용하지 않음
     if (url.startsWith('/auth')) {
       return true;
     }
 
-    // {authorization: 'Basic {token}'}
+    // 요청 헤더에서 'authorization' 필드를 추출
     const rawToken = req.headers['authorization'];
+    // 토큰이 없는 경우 UnauthorizedException 발생
     if (!rawToken) {
       throw new UnauthorizedException('토큰이 없습니다.');
     }
+    // AuthService를 사용하여 토큰에서 필요한 정보 추출
     const token = this.authService.extractTokenFromHeader(rawToken);
     const result = await this.authService.verifyToken(token);
+
+    // 토큰이 refresh 토큰인 경우 오류 발생
     if (result.tokenType === 'refresh') {
       throw new UnauthorizedException('엑세스 토큰이 아닙니다.');
     }
+
+    // 사용자 ID 추출 및 검증
     const userId = result?.userId;
     if (!userId) {
       throw new UnauthorizedException('엑세스 토큰이 잘못되었습니다.');
     }
+    // 요청 객체에 userId 추가
     req.userId = userId;
 
     return true;

--- a/server/src/auth/guard/access-token.guard.ts
+++ b/server/src/auth/guard/access-token.guard.ts
@@ -1,0 +1,40 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class AccessTokenGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const url = req.url;
+
+    // /auth 경로는 Guard를 적용하지 않음
+    if (url.startsWith('/auth')) {
+      return true;
+    }
+
+    // {authorization: 'Basic {token}'}
+    const rawToken = req.headers['authorization'];
+    if (!rawToken) {
+      throw new UnauthorizedException('토큰이 없습니다.');
+    }
+    const token = this.authService.extractTokenFromHeader(rawToken);
+    const result = await this.authService.verifyToken(token);
+    if (result.tokenType === 'refresh') {
+      throw new UnauthorizedException('엑세스 토큰이 아닙니다.');
+    }
+    const userId = result?.userId;
+    if (!userId) {
+      throw new UnauthorizedException('엑세스 토큰이 잘못되었습니다.');
+    }
+    req.userId = userId;
+
+    return true;
+  }
+}

--- a/server/src/folders/folders.controller.ts
+++ b/server/src/folders/folders.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
+import { UserId } from 'src/users/decorator/userId.decorator';
 import { CreateFolderDto } from './dto/create-folder.dto';
 import { UpdateFolderDto } from './dto/update-folder.dto';
 import { FoldersService } from './folders.service';
@@ -16,32 +17,34 @@ export class FoldersController {
   constructor(private readonly foldersService: FoldersService) {}
 
   @Post()
-  postFolder(@Body() createFolderDto: CreateFolderDto) {
-    const userId: number = 2;
+  postFolder(
+    @UserId() userId: number,
+    @Body() createFolderDto: CreateFolderDto,
+  ) {
     return this.foldersService.createFolder(userId, createFolderDto);
   }
 
   @Get()
-  getFolders() {
-    const userId: number = 2;
+  getFolders(@UserId() userId: number) {
     return this.foldersService.findAllFolders(userId);
   }
 
   @Get(':forderId')
-  getFolder(@Param('forderId') forderId: number) {
-    return this.foldersService.findFolderById(forderId);
+  getFolder(@Param('forderId') forderId: number, @UserId() userId: number) {
+    return this.foldersService.findFolderById(forderId, userId);
   }
 
   @Put(':forderId')
   putFolder(
     @Param('forderId') forderId: number,
+    @UserId() userId: number,
     @Body() updateFolderDto: UpdateFolderDto,
   ) {
-    return this.foldersService.updateFolder(forderId, updateFolderDto);
+    return this.foldersService.updateFolder(forderId, userId, updateFolderDto);
   }
 
   @Delete(':forderId')
-  deleteFolder(@Param('forderId') forderId: number) {
-    return this.foldersService.removeFolder(forderId);
+  deleteFolder(@Param('forderId') forderId: number, @UserId() userId: number) {
+    return this.foldersService.removeFolder(forderId, userId);
   }
 }

--- a/server/src/folders/folders.service.spec.ts
+++ b/server/src/folders/folders.service.spec.ts
@@ -78,7 +78,7 @@ describe('FoldersService', () => {
     expect(mockFoldersRepository.save).toHaveBeenCalledWith(
       expectedFolderObject,
     ); // 수정된 부분
-    expect(result).toEqual({ folderId: 1, ...expectedFolderObject });
+    expect(result).toEqual({ folderId: 1, ...createFolderDto });
   });
 
   it('service.createFolder(createFolderDto) : 이미 존재하는 폴더명일 경우 BadRequestException을 던진다.', async () => {
@@ -124,8 +124,7 @@ describe('FoldersService', () => {
     const result = await service.findFolderById(1, 1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { folderId: 1 },
-      relations: ['owner'],
+      where: { folderId: 1, owner: { userId: 1 } },
     });
     expect(result).toEqual(folder);
   });
@@ -155,8 +154,7 @@ describe('FoldersService', () => {
     const result = await service.updateFolder(1, 1, updateFolderDto);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { folderId: 1 },
-      relations: ['owner'],
+      where: { folderId: 1, owner: { userId: 1 } },
     });
     expect(mockFoldersRepository.save).toHaveBeenCalledWith({
       ...existingFolder,
@@ -182,8 +180,7 @@ describe('FoldersService', () => {
     const result = await service.removeFolder(1, 1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
-      where: { folderId: 1 },
-      relations: ['owner'],
+      where: { folderId: 1, owner: { userId: 1 } },
     });
     expect(mockFoldersRepository.remove).toHaveBeenCalledWith(folder);
     expect(result).toEqual({ message: '삭제되었습니다.' });

--- a/server/src/folders/folders.service.spec.ts
+++ b/server/src/folders/folders.service.spec.ts
@@ -121,7 +121,7 @@ describe('FoldersService', () => {
     const folder = { folderId: 1, title: 'blackpink in your area' };
     mockFoldersRepository.findOne.mockResolvedValue(folder);
 
-    const result = await service.findFolderById(1);
+    const result = await service.findFolderById(1, 1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
       where: { folderId: 1 },
@@ -133,7 +133,7 @@ describe('FoldersService', () => {
   it('service.findFolderById(folderId) : 존재하지 않는 폴더명일 경우 BadRequestException을 던진다.', async () => {
     mockFoldersRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.findFolderById(1)).rejects.toThrow(
+    await expect(service.findFolderById(1, 1)).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -152,7 +152,7 @@ describe('FoldersService', () => {
       ...updateFolderDto,
     });
 
-    const result = await service.updateFolder(1, updateFolderDto);
+    const result = await service.updateFolder(1, 1, updateFolderDto);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
       where: { folderId: 1 },
@@ -169,9 +169,9 @@ describe('FoldersService', () => {
     const updateFolderDto: UpdateFolderDto = { title: 'UpdatedFolder' };
     mockFoldersRepository.findOne.mockResolvedValueOnce(null); // 폴더가 존재하지 않는다고 가정
 
-    await expect(service.updateFolder(9999, updateFolderDto)).rejects.toThrow(
-      BadRequestException,
-    );
+    await expect(
+      service.updateFolder(9999, 1, updateFolderDto),
+    ).rejects.toThrow(BadRequestException);
   });
 
   it('service.removeFolder(folderId) : folderId에 해당하는 폴더를 삭제한다.', async () => {
@@ -179,7 +179,7 @@ describe('FoldersService', () => {
     mockFoldersRepository.findOne.mockResolvedValue(folder);
     mockFoldersRepository.remove.mockResolvedValue(folder);
 
-    const result = await service.removeFolder(1);
+    const result = await service.removeFolder(1, 1);
 
     expect(mockFoldersRepository.findOne).toHaveBeenCalledWith({
       where: { folderId: 1 },
@@ -192,7 +192,7 @@ describe('FoldersService', () => {
   it('service.removeFolder(folderId) : 존재하지 않는 폴더 ID에 대한 처리를 검증한다.', async () => {
     mockFoldersRepository.findOne.mockResolvedValueOnce(null); // 폴더가 존재하지 않는다고 가정
 
-    await expect(service.removeFolder(9999)).rejects.toThrow(
+    await expect(service.removeFolder(9999, 1)).rejects.toThrow(
       BadRequestException,
     );
   });

--- a/server/src/folders/private-checklists/private-checklists.controller.ts
+++ b/server/src/folders/private-checklists/private-checklists.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
+import { UserId } from 'src/users/decorator/userId.decorator';
 import { CreatePrivateChecklistDto } from './dto/create-private-checklist.dto';
 import { UpdatePrivateChecklistDto } from './dto/update-private-checklist.dto';
 import { PrivateChecklistsService } from './private-checklists.service';
@@ -24,10 +25,10 @@ export class PrivateChecklistsController {
   @Post()
   postPrivateChecklist(
     @Param('folderId') folderId: number,
+    @UserId() userId: number,
     @Body() dto: CreatePrivateChecklistDto,
   ) {
-    const userId: number = 2;
-    return this.checklistsService.createPrivateChecklist(userId, folderId, dto);
+    return this.checklistsService.createPrivateChecklist(folderId, userId, dto);
   }
 
   /**
@@ -36,8 +37,11 @@ export class PrivateChecklistsController {
    * @returns {Promise<PrivateChecklistModel[]>}
    */
   @Get()
-  getAllPrivateChecklists(@Param('folderId') folderId: number) {
-    return this.checklistsService.findAllPrivateChecklists(folderId);
+  getAllPrivateChecklists(
+    @Param('folderId') folderId: number,
+    @UserId() userId: number,
+  ) {
+    return this.checklistsService.findAllPrivateChecklists(folderId, userId);
   }
 
   /**
@@ -46,8 +50,16 @@ export class PrivateChecklistsController {
    * @returns {Promise<PrivateChecklistModel>}
    */
   @Get(':privateChecklistId')
-  getPrivateChecklist(@Param('privateChecklistId') privateChecklistId: number) {
-    return this.checklistsService.findPrivateChecklistById(privateChecklistId);
+  getPrivateChecklist(
+    @Param('folderId') folderId: number,
+    @Param('privateChecklistId') privateChecklistId: number,
+    @UserId() userId: number,
+  ) {
+    return this.checklistsService.findPrivateChecklistById(
+      folderId,
+      privateChecklistId,
+      userId,
+    );
   }
 
   /**
@@ -58,11 +70,15 @@ export class PrivateChecklistsController {
    */
   @Put(':privateChecklistId')
   putPrivateChecklist(
+    @Param('folderId') folderId: number,
     @Param('privateChecklistId') privateChecklistId: number,
+    @UserId() userId: number,
     @Body() dto: UpdatePrivateChecklistDto,
   ) {
     return this.checklistsService.updatePrivateChecklist(
+      folderId,
       privateChecklistId,
+      userId,
       dto,
     );
   }
@@ -74,8 +90,14 @@ export class PrivateChecklistsController {
    */
   @Delete(':privateChecklistId')
   deletePrivateChecklist(
+    @Param('folderId') folderId: number,
     @Param('privateChecklistId') privateChecklistId: number,
+    @UserId() userId: number,
   ) {
-    return this.checklistsService.removePrivateChecklist(privateChecklistId);
+    return this.checklistsService.removePrivateChecklist(
+      folderId,
+      privateChecklistId,
+      userId,
+    );
   }
 }

--- a/server/src/folders/private-checklists/private-checklists.service.spec.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.spec.ts
@@ -75,8 +75,8 @@ describe('PrivateChecklistsService', () => {
     const createDto = new CreatePrivateChecklistDto();
     const expectedChecklistObject = {
       ...createDto,
-      editor: user,
-      folder: folder,
+      editor: { userId: 1 },
+      folder: { folderId: 1 },
     };
 
     mockChecklistRepository.create.mockReturnValue(expectedChecklistObject);
@@ -84,8 +84,7 @@ describe('PrivateChecklistsService', () => {
 
     const result = await service.createPrivateChecklist(1, 1, createDto);
 
-    expect(mockUsersService.findUserById).toHaveBeenCalledWith(1);
-    expect(mockFoldersService.findFolderById).toHaveBeenCalledWith(1);
+    expect(mockFoldersService.findFolderById).toHaveBeenCalledWith(1, 1);
 
     expect(mockChecklistRepository.create).toHaveBeenCalledWith(
       expectedChecklistObject,
@@ -106,7 +105,7 @@ describe('PrivateChecklistsService', () => {
     const result = await service.findAllPrivateChecklists(1, 1);
 
     expect(mockChecklistRepository.find).toHaveBeenCalledWith({
-      where: { folder: { folderId: 1 } },
+      where: { folder: { folderId: 1 }, editor: { userId: 1 } },
     });
     expect(result).toEqual(checklists);
   });
@@ -118,7 +117,11 @@ describe('PrivateChecklistsService', () => {
     const result = await service.findPrivateChecklistById(1, 1, 1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { privateChecklistId: 1 },
+      where: {
+        privateChecklistId: 1,
+        folder: { folderId: 1 },
+        editor: { userId: 1 },
+      },
     });
     expect(result).toEqual(checklist);
   });
@@ -143,7 +146,11 @@ describe('PrivateChecklistsService', () => {
     const result = await service.updatePrivateChecklist(1, 1, 1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { privateChecklistId: 1 },
+      where: {
+        privateChecklistId: 1,
+        folder: { folderId: 1 },
+        editor: { userId: 1 },
+      },
     });
     expect(mockChecklistRepository.save).toHaveBeenCalledWith({
       ...existingChecklist,
@@ -167,7 +174,11 @@ describe('PrivateChecklistsService', () => {
     const result = await service.updatePrivateChecklist(1, 1, 1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { privateChecklistId: 1 },
+      where: {
+        privateChecklistId: 1,
+        folder: { folderId: 1 },
+        editor: { userId: 1 },
+      },
     });
     expect(mockChecklistRepository.save).toHaveBeenCalledWith({
       ...existingChecklist,
@@ -192,7 +203,11 @@ describe('PrivateChecklistsService', () => {
     const result = await service.removePrivateChecklist(1, 1, 1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
-      where: { privateChecklistId: 1 },
+      where: {
+        privateChecklistId: 1,
+        folder: { folderId: 1 },
+        editor: { userId: 1 },
+      },
     });
     expect(mockChecklistRepository.remove).toHaveBeenCalledWith(checklist);
     expect(result).toEqual({ message: '삭제되었습니다.' });

--- a/server/src/folders/private-checklists/private-checklists.service.spec.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.spec.ts
@@ -103,7 +103,7 @@ describe('PrivateChecklistsService', () => {
     ];
     mockChecklistRepository.find.mockResolvedValue(checklists);
 
-    const result = await service.findAllPrivateChecklists(1);
+    const result = await service.findAllPrivateChecklists(1, 1);
 
     expect(mockChecklistRepository.find).toHaveBeenCalledWith({
       where: { folder: { folderId: 1 } },
@@ -115,7 +115,7 @@ describe('PrivateChecklistsService', () => {
     const checklist = new PrivateChecklistModel();
     mockChecklistRepository.findOne.mockResolvedValue(checklist);
 
-    const result = await service.findPrivateChecklistById(1);
+    const result = await service.findPrivateChecklistById(1, 1, 1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
       where: { privateChecklistId: 1 },
@@ -126,7 +126,7 @@ describe('PrivateChecklistsService', () => {
   it('service.findPrivateChecklistById(privateChecklistId) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.findPrivateChecklistById(1)).rejects.toThrow(
+    await expect(service.findPrivateChecklistById(1, 1, 1)).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -140,7 +140,7 @@ describe('PrivateChecklistsService', () => {
       ...updateDto,
     });
 
-    const result = await service.updatePrivateChecklist(1, updateDto);
+    const result = await service.updatePrivateChecklist(1, 1, 1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
       where: { privateChecklistId: 1 },
@@ -164,7 +164,7 @@ describe('PrivateChecklistsService', () => {
       ...updateDto,
     });
 
-    const result = await service.updatePrivateChecklist(1, updateDto);
+    const result = await service.updatePrivateChecklist(1, 1, 1, updateDto);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
       where: { privateChecklistId: 1 },
@@ -180,16 +180,16 @@ describe('PrivateChecklistsService', () => {
     const updateDto = new UpdatePrivateChecklistDto();
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.updatePrivateChecklist(1, updateDto)).rejects.toThrow(
-      BadRequestException,
-    );
+    await expect(
+      service.updatePrivateChecklist(1, 1, 1, updateDto),
+    ).rejects.toThrow(BadRequestException);
   });
 
   it('service.removePrivateChecklist(privateChecklistId) : 체크리스트를 삭제한다.', async () => {
     const checklist = new PrivateChecklistModel();
     mockChecklistRepository.findOne.mockResolvedValue(checklist);
 
-    const result = await service.removePrivateChecklist(1);
+    const result = await service.removePrivateChecklist(1, 1, 1);
 
     expect(mockChecklistRepository.findOne).toHaveBeenCalledWith({
       where: { privateChecklistId: 1 },
@@ -201,7 +201,7 @@ describe('PrivateChecklistsService', () => {
   it('service.removePrivateChecklist(privateChecklistId) : 존재하지 않는 체크리스트일 경우 BadRequestException을 던진다.', async () => {
     mockChecklistRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.removePrivateChecklist(1)).rejects.toThrow(
+    await expect(service.removePrivateChecklist(1, 1, 1)).rejects.toThrow(
       BadRequestException,
     );
   });

--- a/server/src/folders/private-checklists/private-checklists.service.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.ts
@@ -23,7 +23,7 @@ export class PrivateChecklistsService {
   ) {
     // 1. folderId를 통해 해당 folder가 존재하는지 확인합니다.
     // userId를 통해 user entity를 가져옵니다.
-    const folder = await this.foldersService.findFolderById(folderId);
+    const folder = await this.foldersService.findFolderById(folderId, userId);
     const user = await this.usersService.findUserById(userId);
 
     // 3. 새로운 checklist를 생성합니다.
@@ -69,7 +69,8 @@ export class PrivateChecklistsService {
     }
 
     if (folderId) {
-      const folder = await this.foldersService.findFolderById(folderId);
+      const userId = 2;
+      const folder = await this.foldersService.findFolderById(folderId, userId);
       checklist.folder = folder;
     }
 

--- a/server/src/folders/private-checklists/private-checklists.service.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.ts
@@ -17,8 +17,8 @@ export class PrivateChecklistsService {
   ) {}
 
   async createPrivateChecklist(
-    userId: number,
     folderId: number,
+    userId: number,
     dto: CreatePrivateChecklistDto,
   ) {
     // 1. folderId를 통해 해당 folder가 존재하는지 확인합니다.

--- a/server/src/folders/private-checklists/private-checklists.service.ts
+++ b/server/src/folders/private-checklists/private-checklists.service.ts
@@ -1,7 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UsersService } from '../../users/users.service';
 import { FoldersService } from '../folders.service';
 import { CreatePrivateChecklistDto } from './dto/create-private-checklist.dto';
 import { UpdatePrivateChecklistDto } from './dto/update-private-checklist.dto';
@@ -12,8 +11,7 @@ export class PrivateChecklistsService {
   constructor(
     @InjectRepository(PrivateChecklistModel)
     private readonly repository: Repository<PrivateChecklistModel>,
-    private readonly foldersService: FoldersService,
-    private readonly usersService: UsersService,
+    private readonly foldersService: FoldersService, // private readonly usersService: UsersService,
   ) {}
 
   async createPrivateChecklist(
@@ -24,29 +22,33 @@ export class PrivateChecklistsService {
     // 1. folderId를 통해 해당 folder가 존재하는지 확인합니다.
     // userId를 통해 user entity를 가져옵니다.
     const folder = await this.foldersService.findFolderById(folderId, userId);
-    const user = await this.usersService.findUserById(userId);
+    // const user = await this.usersService.findUserById(userId);
 
     // 3. 새로운 checklist를 생성합니다.
     const newChecklist = this.repository.create({
       ...dto,
-      editor: user,
-      folder: folder,
+      editor: { userId },
+      folder: { folderId },
     });
 
     // 4. 생성된 checklist를 저장하고, 해당 checklist를 반환합니다.
     return this.repository.save(newChecklist);
   }
 
-  async findAllPrivateChecklists(folderId: number) {
+  async findAllPrivateChecklists(folderId: number, userId: number) {
     const checklists = await this.repository.find({
-      where: { folder: { folderId } },
+      where: { folder: { folderId }, editor: { userId } },
     });
     return checklists;
   }
 
-  async findPrivateChecklistById(privateChecklistId: number) {
+  async findPrivateChecklistById(
+    folderId: number,
+    privateChecklistId: number,
+    userId: number,
+  ) {
     const checklist = await this.repository.findOne({
-      where: { privateChecklistId },
+      where: { privateChecklistId, folder: { folderId }, editor: { userId } },
     });
     if (!checklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');
@@ -55,11 +57,17 @@ export class PrivateChecklistsService {
   }
 
   async updatePrivateChecklist(
+    folderId: number,
     privateChecklistId: number,
+    userId: number,
     dto: UpdatePrivateChecklistDto,
   ) {
-    const { title, folderId, items } = dto;
-    const checklist = await this.findPrivateChecklistById(privateChecklistId);
+    const { title, folderId: newFolderId, items } = dto;
+    const checklist = await this.findPrivateChecklistById(
+      folderId,
+      privateChecklistId,
+      userId,
+    );
     if (!checklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');
     }
@@ -68,9 +76,11 @@ export class PrivateChecklistsService {
       checklist.title = title;
     }
 
-    if (folderId) {
-      const userId = 2;
-      const folder = await this.foldersService.findFolderById(folderId, userId);
+    if (newFolderId) {
+      const folder = await this.foldersService.findFolderById(
+        newFolderId,
+        userId,
+      );
       checklist.folder = folder;
     }
 
@@ -82,8 +92,16 @@ export class PrivateChecklistsService {
     return newChecklist;
   }
 
-  async removePrivateChecklist(privateChecklistId: number) {
-    const checklist = await this.findPrivateChecklistById(privateChecklistId);
+  async removePrivateChecklist(
+    folderId: number,
+    privateChecklistId: number,
+    userId: number,
+  ) {
+    const checklist = await this.findPrivateChecklistById(
+      folderId,
+      privateChecklistId,
+      userId,
+    );
 
     // soft-delete 방식으로 수정필요
     await this.repository.remove(checklist);

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -2,9 +2,15 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { AppModule } from './app.module';
+import { AuthService } from './auth/auth.service';
+import { AccessTokenGuard } from './auth/guard/access-token.guard';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  // AccessTokenGuard 전역 Guard로 설정
+  const authService = app.get(AuthService);
+  app.useGlobalGuards(new AccessTokenGuard(authService));
+
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true, // 요청에서 넘어온 자료들의 형변환을 자동으로 해줌

--- a/server/src/users/decorator/userId.decorator.ts
+++ b/server/src/users/decorator/userId.decorator.ts
@@ -1,0 +1,21 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+/**
+ * @UserId 커스텀 데코레이터
+ * ExecutionContext로부터 HTTP 요청을 추출하고, 해당 요청에서 userId를 반환한다.
+ * 이 데코레이터는 컨트롤러의 핸들러 메소드에서 사용되며, 인증된 사용자의 식별자를 제공한다.
+ * 요청 객체에 사용자 정보가 없는 경우 InternalServerErrorException을 발생시킨다.
+ */
+export const UserId = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    if (!request.userId) {
+      throw new InternalServerErrorException('사용자 정보가 없습니다.');
+    }
+    return request.userId;
+  },
+);

--- a/server/src/users/entities/user.entity.ts
+++ b/server/src/users/entities/user.entity.ts
@@ -2,7 +2,6 @@ import { BaseModel } from 'src/common/entity/base.entity';
 import {
   Column,
   Entity,
-  Generated,
   ManyToMany,
   OneToMany,
   PrimaryGeneratedColumn,


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #123 

## 고민과 해결 과정

### 고민
- AccessTokenGuard를 전역적으로 적용하는 방법에 대해 고민했다.

### 해결
- main.ts에 적용하면 된다.
- ```typescript    
  // AccessTokenGuard 전역 Guard로 설정
  const authService = app.get(AuthService);
  app.useGlobalGuards(new AccessTokenGuard(authService));
  ```
- 그리고 AccessTokenGuard에서 auth만 경로를 제외해주면 된다.
- ```typescript    
    // /auth 경로에 대한 요청은 Guard를 적용하지 않음
    if (url.startsWith('/auth')) {
      return true;
    }

  ```
## 스크린샷
- 엑세스 토큰이 없는 경우
- <img width="974" alt="스크린샷 2023-11-29 오전 11 10 29" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/26b7323a-2554-4b36-8cd4-bcc5b60086ce">

- 엑세스 토큰이 있는 경우
- <img width="965" alt="스크린샷 2023-11-29 오전 11 10 55" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/6e012bc1-a963-4752-bc70-a23f21245991">

## 테스트 결과(커버리지/테스트 결과)
<img width="736" alt="스크린샷 2023-11-29 오전 11 09 29" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/a96dfca3-ae35-448d-8f12-e91d4af8aaff">
