### PR TITLE
[Server] 공유 체크리스트 API 및 소켓 작업 구현

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -18,7 +18,7 @@ import { FolderModel } from './folders/entities/folder.entity';
 import { FoldersModule } from './folders/folders.module';
 import { PrivateChecklistModel } from './folders/private-checklists/entities/private-checklist.entity';
 import { ChecklistsModule } from './folders/private-checklists/private-checklists.module';
-import { ShaerdChecklistItemModel } from './shared-checklists/entities/shared-checklist-item.entity';
+import { SharedChecklistItemModel } from './shared-checklists/entities/shared-checklist-item.entity';
 import { SharedChecklistModel } from './shared-checklists/entities/shared-checklist.entity';
 import { SharedChecklistsModule } from './shared-checklists/shared-checklists.module';
 import { UserModel } from './users/entities/user.entity';
@@ -43,7 +43,7 @@ import { winstonConfig } from './utils/winston.config';
         FolderModel,
         PrivateChecklistModel,
         SharedChecklistModel,
-        ShaerdChecklistItemModel,
+        SharedChecklistItemModel,
       ],
       synchronize: true, // DO NOT USE IN PRODUCTION
     }),

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -10,19 +10,20 @@ import { WinstonModule } from 'nest-winston';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { CategoriesModule } from './categories/categories.module';
+import { ChecklistAiModule } from './checklist-ai/checklist-ai.module';
 import { CommonModule } from './common/common.module';
 import { LoggerMiddleware } from './common/middlewares/logger.middleware';
 import { FolderModel } from './folders/entities/folder.entity';
 import { FoldersModule } from './folders/folders.module';
 import { PrivateChecklistModel } from './folders/private-checklists/entities/private-checklist.entity';
 import { ChecklistsModule } from './folders/private-checklists/private-checklists.module';
+import { ShaerdChecklistItemModel } from './shared-checklists/entities/shared-checklist-item.entity';
 import { SharedChecklistModel } from './shared-checklists/entities/shared-checklist.entity';
 import { SharedChecklistsModule } from './shared-checklists/shared-checklists.module';
 import { UserModel } from './users/entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { winstonConfig } from './utils/winston.config';
-import { ChecklistAiModule } from './checklist-ai/checklist-ai.module';
-import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { CategoriesModule } from './categories/categories.module';
         FolderModel,
         PrivateChecklistModel,
         SharedChecklistModel,
+        ShaerdChecklistItemModel,
       ],
       synchronize: true, // DO NOT USE IN PRODUCTION
     }),

--- a/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
+++ b/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
@@ -1,4 +1,5 @@
 import { PickType } from '@nestjs/mapped-types';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { SharedChecklistModel } from '../entities/shared-checklist.entity';
 
 export class CreateSharedChecklistDto extends PickType(SharedChecklistModel, [
@@ -8,4 +9,14 @@ export class CreateSharedChecklistDto extends PickType(SharedChecklistModel, [
 ]) {
   // @IsNumber({}, { each: true })
   // editorsId: number[] = [];
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  sharedChecklistId: string;
+
+  @IsNotEmpty()
+  items: any;
 }

--- a/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
+++ b/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
@@ -1,10 +1,11 @@
 import { PickType } from '@nestjs/mapped-types';
 import { SharedChecklistModel } from '../entities/shared-checklist.entity';
-import { IsNumber } from 'class-validator';
 
 export class CreateSharedChecklistDto extends PickType(SharedChecklistModel, [
   'title',
+  'sharedChecklistId',
+  'items',
 ]) {
-  @IsNumber({}, { each: true })
-  editorsId: number[] = [];
+  // @IsNumber({}, { each: true })
+  // editorsId: number[] = [];
 }

--- a/server/src/shared-checklists/entities/shared-checklist-item.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist-item.entity.ts
@@ -1,0 +1,18 @@
+import { BaseModel } from 'src/common/entity/base.entity';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { SharedChecklistModel } from './shared-checklist.entity';
+
+@Entity()
+export class ShaerdChecklistItemModel extends BaseModel {
+  @PrimaryGeneratedColumn()
+  itemId: number;
+
+  @ManyToOne(
+    () => SharedChecklistModel,
+    (sharedChecklist) => sharedChecklist.items,
+  )
+  sharedChecklist: SharedChecklistModel;
+
+  @Column({ type: 'json' })
+  messages: any[];
+}

--- a/server/src/shared-checklists/entities/shared-checklist-item.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist-item.entity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { SharedChecklistModel } from './shared-checklist.entity';
 
 @Entity()
-export class ShaerdChecklistItemModel extends BaseModel {
+export class SharedChecklistItemModel extends BaseModel {
   @PrimaryGeneratedColumn()
   itemId: number;
 

--- a/server/src/shared-checklists/entities/shared-checklist.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist.entity.ts
@@ -7,7 +7,7 @@ import {
 } from 'typeorm';
 import { ChecklistModel } from '../../common/entity/checklist.entity';
 import { UserModel } from '../../users/entities/user.entity';
-import { ShaerdChecklistItemModel } from './shared-checklist-item.entity';
+import { SharedChecklistItemModel } from './shared-checklist-item.entity';
 
 @Entity()
 export class SharedChecklistModel extends ChecklistModel {
@@ -20,6 +20,6 @@ export class SharedChecklistModel extends ChecklistModel {
   @JoinTable()
   editors: UserModel[];
 
-  @OneToMany(() => ShaerdChecklistItemModel, (item) => item.sharedChecklist)
-  items: ShaerdChecklistItemModel[];
+  @OneToMany(() => SharedChecklistItemModel, (item) => item.sharedChecklist)
+  items: SharedChecklistItemModel[];
 }

--- a/server/src/shared-checklists/entities/shared-checklist.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist.entity.ts
@@ -3,7 +3,7 @@ import {
   JoinTable,
   ManyToMany,
   OneToMany,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
 } from 'typeorm';
 import { ChecklistModel } from '../../common/entity/checklist.entity';
 import { UserModel } from '../../users/entities/user.entity';
@@ -11,8 +11,8 @@ import { SharedChecklistItemModel } from './shared-checklist-item.entity';
 
 @Entity()
 export class SharedChecklistModel extends ChecklistModel {
-  @PrimaryGeneratedColumn()
-  sharedChecklistId: number;
+  @PrimaryColumn({ type: 'uuid' })
+  sharedChecklistId: string;
 
   @ManyToMany(() => UserModel, (user) => user.sharedChecklists, {
     nullable: false,

--- a/server/src/shared-checklists/entities/shared-checklist.entity.ts
+++ b/server/src/shared-checklists/entities/shared-checklist.entity.ts
@@ -1,14 +1,25 @@
-import { Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { ChecklistModel } from '../../common/entity/checklist.entity';
 import { UserModel } from '../../users/entities/user.entity';
+import { ShaerdChecklistItemModel } from './shared-checklist-item.entity';
 
 @Entity()
 export class SharedChecklistModel extends ChecklistModel {
   @PrimaryGeneratedColumn()
   sharedChecklistId: number;
+
   @ManyToMany(() => UserModel, (user) => user.sharedChecklists, {
     nullable: false,
   })
   @JoinTable()
   editors: UserModel[];
+
+  @OneToMany(() => ShaerdChecklistItemModel, (item) => item.sharedChecklist)
+  items: ShaerdChecklistItemModel[];
 }

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   Param,
   Post,
-  Put,
   Query,
 } from '@nestjs/common';
 import { UserId } from 'src/users/decorator/userId.decorator';
@@ -53,7 +52,11 @@ export class SharedChecklistsController {
     @UserId() userId: number,
     @Query('date') date?: string, // 새로운 쿼리 파라미터 추가
   ) {
-    return this.checklistsService.findSharedChecklistById(cid, userId, date);
+    return this.checklistsService.findSharedChecklistAndItemsById(
+      cid,
+      userId,
+      date,
+    );
   }
 
   /**
@@ -62,15 +65,12 @@ export class SharedChecklistsController {
    * @param {UpdateSharedChecklistDto} updateChecklistDto
    * @returns {Promise<SharedChecklistModel>}
    */
-  @Put(':checklistId')
+  @Post(':checklistId/editors')
   updateSharedChecklist(
     @Param('checklistId') cid: string,
-    @Body() updateChecklistDto: UpdateSharedChecklistDto,
+    @UserId() userId: number,
   ) {
-    return this.checklistsService.updateSharedChecklist(
-      cid,
-      updateChecklistDto,
-    );
+    return this.checklistsService.addEditor(cid, userId);
   }
 
   /**

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { UserId } from 'src/users/decorator/userId.decorator';
 import { CreateSharedChecklistDto } from './dto/create-shared-checklist.dto';
@@ -47,8 +48,12 @@ export class SharedChecklistsController {
    * @returns {Promise<SharedChecklistModel>}
    */
   @Get(':checklistId')
-  getSharedChecklist(@Param('checklistId') cid: string) {
-    return this.checklistsService.findSharedChecklistById(cid);
+  getSharedChecklist(
+    @Param('checklistId') cid: string,
+    @UserId() userId: number,
+    @Query('date') date?: string, // 새로운 쿼리 파라미터 추가
+  ) {
+    return this.checklistsService.findSharedChecklistById(cid, userId, date);
   }
 
   /**

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -26,7 +26,7 @@ export class SharedChecklistsController {
     @UserId() userId: number,
     @Body() createSharedChecklistDto: CreateSharedChecklistDto,
   ) {
-    return this.checklistsService.createSharedChecklist(
+    return this.checklistsService.createSharedChecklistWithItems(
       userId,
       createSharedChecklistDto,
     );

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -12,7 +12,7 @@ import { CreateSharedChecklistDto } from './dto/create-shared-checklist.dto';
 import { UpdateSharedChecklistDto } from './dto/update-shared-checklist.dto';
 import { SharedChecklistsService } from './shared-checklists.service';
 
-@Controller('folders/:folderId/checklists')
+@Controller('shared-checklists')
 export class SharedChecklistsController {
   constructor(private readonly checklistsService: SharedChecklistsService) {}
 
@@ -37,8 +37,8 @@ export class SharedChecklistsController {
    * @returns {Promise<SharedChecklistModel[]>}
    */
   @Get()
-  getAllSharedChecklists() {
-    return this.checklistsService.findAllSharedChecklists();
+  getAllSharedChecklists(@UserId() userId: number) {
+    return this.checklistsService.findAllSharedChecklists(userId);
   }
 
   /**

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -1,15 +1,16 @@
 import {
-  Controller,
-  Get,
-  Post,
   Body,
-  Param,
+  Controller,
   Delete,
+  Get,
+  Param,
+  Post,
   Put,
 } from '@nestjs/common';
-import { SharedChecklistsService } from './shared-checklists.service';
+import { UserId } from 'src/users/decorator/userId.decorator';
 import { CreateSharedChecklistDto } from './dto/create-shared-checklist.dto';
 import { UpdateSharedChecklistDto } from './dto/update-shared-checklist.dto';
+import { SharedChecklistsService } from './shared-checklists.service';
 
 @Controller('folders/:folderId/checklists')
 export class SharedChecklistsController {
@@ -22,11 +23,11 @@ export class SharedChecklistsController {
    */
   @Post()
   postSharedChecklist(
+    @UserId() userId: number,
     @Body() createSharedChecklistDto: CreateSharedChecklistDto,
   ) {
-    const uId = 1;
     return this.checklistsService.createSharedChecklist(
-      uId,
+      userId,
       createSharedChecklistDto,
     );
   }

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -43,23 +43,23 @@ export class SharedChecklistsController {
 
   /**
    * @description checklistId를 통해 해당 checklist를 조회합니다.
-   * @param {number} cid
+   * @param {string} cid
    * @returns {Promise<SharedChecklistModel>}
    */
   @Get(':checklistId')
-  getSharedChecklist(@Param('checklistId') cid: number) {
+  getSharedChecklist(@Param('checklistId') cid: string) {
     return this.checklistsService.findSharedChecklistById(cid);
   }
 
   /**
    * @description checklistId를 통해 해당 checklist의 title을 수정합니다.
-   * @param {number} cid
+   * @param {string} cid
    * @param {UpdateSharedChecklistDto} updateChecklistDto
    * @returns {Promise<SharedChecklistModel>}
    */
   @Put(':checklistId')
   updateSharedChecklist(
-    @Param('checklistId') cid: number,
+    @Param('checklistId') cid: string,
     @Body() updateChecklistDto: UpdateSharedChecklistDto,
   ) {
     return this.checklistsService.updateSharedChecklist(
@@ -70,11 +70,11 @@ export class SharedChecklistsController {
 
   /**
    * @description checklistId를 통해 해당 checklist를 삭제합니다.
-   * @param {number} cid
+   * @param {string} cid
    * @returns {Promise<message:string>}
    */
   @Delete(':checklistId')
-  deleteChecklist(@Param('checklistId') cid: number) {
+  deleteChecklist(@Param('checklistId') cid: string) {
     return this.checklistsService.removeSharedChecklist(cid);
   }
 }

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -79,7 +79,7 @@ export class SharedChecklistsController {
    * @returns {Promise<message:string>}
    */
   @Delete(':checklistId')
-  deleteChecklist(@Param('checklistId') cid: string) {
-    return this.checklistsService.removeSharedChecklist(cid);
+  deleteChecklist(@Param('checklistId') cid: string, @UserId() userId: number) {
+    return this.checklistsService.removeSharedChecklist(cid, userId);
   }
 }

--- a/server/src/shared-checklists/shared-checklists.controller.ts
+++ b/server/src/shared-checklists/shared-checklists.controller.ts
@@ -26,7 +26,7 @@ export class SharedChecklistsController {
     @UserId() userId: number,
     @Body() createSharedChecklistDto: CreateSharedChecklistDto,
   ) {
-    return this.checklistsService.createSharedChecklistWithItems(
+    return this.checklistsService.createSharedChecklistAndItems(
       userId,
       createSharedChecklistDto,
     );
@@ -80,6 +80,6 @@ export class SharedChecklistsController {
    */
   @Delete(':checklistId')
   deleteChecklist(@Param('checklistId') cid: string, @UserId() userId: number) {
-    return this.checklistsService.removeSharedChecklist(cid, userId);
+    return this.checklistsService.removeEditor(cid, userId);
   }
 }

--- a/server/src/shared-checklists/shared-checklists.module.ts
+++ b/server/src/shared-checklists/shared-checklists.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FoldersModule } from '../folders/folders.module';
 import { UsersModule } from '../users/users.module';
+import { SharedChecklistItemModel } from './entities/shared-checklist-item.entity';
 import { SharedChecklistModel } from './entities/shared-checklist.entity';
 import { SharedChecklistsController } from './shared-checklists.controller';
 import { SharedChecklistsGateway } from './shared-checklists.gateway';
@@ -9,7 +10,7 @@ import { SharedChecklistsService } from './shared-checklists.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SharedChecklistModel]),
+    TypeOrmModule.forFeature([SharedChecklistModel, SharedChecklistItemModel]),
     FoldersModule,
     UsersModule,
   ],

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -45,7 +45,7 @@ export class SharedChecklistsService {
     return checklists;
   }
 
-  async findSharedChecklistById(sharedChecklistId: number) {
+  async findSharedChecklistById(sharedChecklistId: string) {
     const checklist = await this.repository.findOne({
       where: { sharedChecklistId },
     });
@@ -55,7 +55,7 @@ export class SharedChecklistsService {
     return checklist;
   }
 
-  async updateSharedChecklist(id: number, dto: UpdateSharedChecklistDto) {
+  async updateSharedChecklist(id: string, dto: UpdateSharedChecklistDto) {
     const { title, editorsId } = dto;
     const checklist = await this.findSharedChecklistById(id);
     if (!checklist) {
@@ -77,7 +77,7 @@ export class SharedChecklistsService {
     return newChecklist;
   }
 
-  async removeSharedChecklist(id: number) {
+  async removeSharedChecklist(id: string) {
     const checklist = await this.findSharedChecklistById(id);
 
     // soft-delete 방식으로 수정필요

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -151,11 +151,12 @@ export class SharedChecklistsService {
     return { message: '추가되었습니다.' };
   }
 
-  async removeSharedChecklist(id: string) {
-    const checklist = await this.findSharedChecklistAndItemsById(id, 1, '');
-
-    // soft-delete 방식으로 수정필요
-    // await this.SharedChecklistsrepository.remove(checklist);
+  async removeSharedChecklist(id: string, userId: number) {
+    const checklist = await this.findSharedChecklistById(id);
+    checklist.editors = checklist.editors.filter(
+      (editor) => editor.userId !== userId,
+    );
+    await this.SharedChecklistsrepository.save(checklist);
     return { message: '삭제되었습니다.' };
   }
 }

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -26,14 +26,14 @@ export class SharedChecklistsService {
     }
 
     // 2. editorsId를 통해 해당 유저들이 존재하는지 확인하고 가져옵니다.
-    const editors = await Promise.all(
-      dto.editorsId.map((id) => this.usersService.findUserById(id)),
-    );
+    // const editors = await Promise.all(
+    //   dto.editorsId.map((id) => this.usersService.findUserById(id)),
+    // );
 
     // 3. 새로운 checklist를 생성합니다.
     const newChecklist = this.repository.create({
       title: dto.title,
-      editors,
+      // editors,
     });
 
     // 4. 생성된 checklist를 저장하고, 해당 checklist를 반환합니다.

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -20,6 +20,12 @@ export class SharedChecklistsService {
 
     private readonly usersService: UsersService,
   ) {}
+  /**
+   * 사용자 ID와 공유 체크리스트 데이터를 받아 새로운 공유 체크리스트를 생성한다.
+   * @param userId 사용자 식별자
+   * @param dto 공유 체크리스트 생성에 필요한 데이터 전송 객체
+   * @returns 생성된 공유 체크리스트 객체
+   */
   async createSharedChecklist(userId: number, dto: CreateSharedChecklistDto) {
     // 중복된 sharedChecklistId가 있는지 확인
     const checklistExists = await this.SharedChecklistsrepository.exist({
@@ -40,6 +46,12 @@ export class SharedChecklistsService {
     return this.SharedChecklistsrepository.save(newChecklist);
   }
 
+  /**
+   * 체크리스트 아이템 데이터와 체크리스트 ID를 받아 새로운 체크리스트 아이템을 생성한다.
+   * @param items 체크리스트 아이템의 메시지 배열
+   * @param checklistId 체크리스트 식별자
+   * @returns 생성된 체크리스트 아이템 객체
+   */
   async createSharedChecklistItem(items: string[], checklistId: string) {
     // 새 ChecklistItem 생성
     const newChecklistItem = this.SharedChecklistItemsrepository.create({
@@ -50,7 +62,13 @@ export class SharedChecklistsService {
     return this.SharedChecklistItemsrepository.save(newChecklistItem);
   }
 
-  async createSharedChecklistWithItems(
+  /**
+   * 사용자 ID와 공유 체크리스트 데이터를 받아 새로운 공유 체크리스트와 체크리스트 아이템을 함께 생성한다.
+   * @param userId 사용자 식별자
+   * @param dto 공유 체크리스트 생성에 필요한 데이터 전송 객체
+   * @returns 생성된 공유 체크리스트와 체크리스트 아이템 객체
+   */
+  async createSharedChecklistAndItems(
     userId: number,
     dto: CreateSharedChecklistDto,
   ) {
@@ -62,6 +80,11 @@ export class SharedChecklistsService {
     return { sharedChecklist, items };
   }
 
+  /**
+   * 사용자 ID를 기반으로 모든 공유 체크리스트를 조회한다.
+   * @param userId 사용자 식별자
+   * @returns 해당 사용자의 모든 공유 체크리스트 배열
+   */
   async findAllSharedChecklists(userId: number) {
     const checklistIdsArray =
       await this.findAllSharedChecklistIdsByUserId(userId);
@@ -75,6 +98,13 @@ export class SharedChecklistsService {
     return checklists;
   }
 
+  /**
+   * 공유 체크리스트 ID와 사용자 ID를 받아 해당 체크리스트와 체크리스트 아이템을 조회한다.
+   * @param sharedChecklistId 공유 체크리스트 식별자
+   * @param userId 사용자 식별자
+   * @param date 특정 날짜 이후의 체크리스트 아이템을 필터링하는 날짜 문자열 (선택적)
+   * @returns 조회된 공유 체크리스트와 체크리스트 아이템 객체
+   */
   async findSharedChecklistAndItemsById(
     sharedChecklistId: string,
     userId: number,
@@ -94,6 +124,11 @@ export class SharedChecklistsService {
     return { sharedChecklist, items };
   }
 
+  /**
+   * 공유 체크리스트 ID를 기반으로 공유 체크리스트를 조회한다.
+   * @param sharedChecklistId 공유 체크리스트 식별자
+   * @returns 조회된 공유 체크리스트 객체
+   */
   async findSharedChecklistById(sharedChecklistId: string) {
     const sharedChecklist = await this.SharedChecklistsrepository.findOne({
       where: { sharedChecklistId },
@@ -105,6 +140,12 @@ export class SharedChecklistsService {
     return sharedChecklist;
   }
 
+  /**
+   * 공유 체크리스트 ID를 기반으로 해당 체크리스트의 모든 아이템을 조회한다.
+   * @param sharedChecklistId 공유 체크리스트 식별자
+   * @param date 선택적 날짜 필터링 (이 날짜 이후의 아이템만 조회)
+   * @returns 조회된 체크리스트 아이템 배열
+   */
   async findSharedChecklistItemsById(sharedChecklistId: string, date?: string) {
     const queryOptions = {
       where: { sharedChecklist: { sharedChecklistId } },
@@ -126,6 +167,11 @@ export class SharedChecklistsService {
     return checklistItems;
   }
 
+  /**
+   * 사용자 ID를 기반으로 해당 사용자가 편집자로 있는 모든 공유 체크리스트 ID를 조회한다.
+   * @param userId 사용자 식별자
+   * @returns 해당 사용자가 편집자로 있는 공유 체크리스트 ID 배열
+   */
   async findAllSharedChecklistIdsByUserId(userId: number) {
     const checklistIdObjects = await this.entityManager.query(
       `SELECT "sharedChecklistModelSharedChecklistId" FROM shared_checklist_model_editors_user_model WHERE "userModelUserId" = $1`,
@@ -136,6 +182,12 @@ export class SharedChecklistsService {
     );
   }
 
+  /**
+   * 공유 체크리스트 ID와 사용자 ID를 기반으로 새로운 에디터를 해당 체크리스트에 추가한다.
+   * @param cid 공유 체크리스트 식별자
+   * @param userId 추가할 사용자 식별자
+   * @returns 추가 작업에 대한 메시지
+   */
   async addEditor(cid: string, userId: number) {
     const checklist = await this.findSharedChecklistById(cid);
     const editorExists = checklist.editors.some(
@@ -151,7 +203,13 @@ export class SharedChecklistsService {
     return { message: '추가되었습니다.' };
   }
 
-  async removeSharedChecklist(id: string, userId: number) {
+  /**
+   * 공유 체크리스트 ID와 사용자 ID를 기반으로 해당 체크리스트에서 사용자를 제거한다.
+   * @param id 공유 체크리스트 식별자
+   * @param userId 제거할 사용자 식별자
+   * @returns 제거 작업에 대한 메시지
+   */
+  async removeEditor(id: string, userId: number) {
     const checklist = await this.findSharedChecklistById(id);
     checklist.editors = checklist.editors.filter(
       (editor) => editor.userId !== userId,

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -50,14 +50,27 @@ export class SharedChecklistsService {
    * 체크리스트 아이템 데이터와 체크리스트 ID를 받아 새로운 체크리스트 아이템을 생성한다.
    * @param items 체크리스트 아이템의 메시지 배열
    * @param checklistId 체크리스트 식별자
+   * @param now  전달되는 현재 시간(옵션)
    * @returns 생성된 체크리스트 아이템 객체
    */
-  async createSharedChecklistItem(items: string[], checklistId: string) {
+  async createSharedChecklistItem(
+    items: string[],
+    checklistId: string,
+    now?: Date,
+  ) {
     // 새 ChecklistItem 생성
-    const newChecklistItem = this.SharedChecklistItemsrepository.create({
+    const checklistItemData = {
       messages: items,
       sharedChecklist: { sharedChecklistId: checklistId },
-    });
+    };
+
+    if (now) {
+      checklistItemData['createdAt'] = now;
+      checklistItemData['updatedAt'] = now;
+    }
+
+    const newChecklistItem =
+      this.SharedChecklistItemsrepository.create(checklistItemData);
 
     return this.SharedChecklistItemsrepository.save(newChecklistItem);
   }


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #133 

## 고민과 해결 과정
### 고민
- 조인 테이블을 사용하고 싶은데 typeorm이 지원하지 않는다.
- 동시 편집시 데이터 동기화를 어떻게 해야할까

### 해결
- entityManager를 통해 직접 쿼리를 작성할 수 있다.
- ```ts
    async findAllSharedChecklistIdsByUserId(userId: number) {
    const checklistIdObjects = await this.entityManager.query(
      `SELECT "sharedChecklistModelSharedChecklistId" FROM shared_checklist_model_editors_user_model WHERE "userModelUserId" = $1`,
      [userId],
    );
    return checklistIdObjects.map(
      (obj) => obj.sharedChecklistModelSharedChecklistId,
    );
  }
  ```
- 맵 자료형을 사용한다.
- ```ts
  // 각 checklist ID별로 연결된 클라이언트들을 추적하기 위한 맵
  private clients: Map<string, Set<WebSocket>> = new Map();
  // 각 checklist ID별로 전송된 데이터를 저장하기 위한 맵
  private checklistData: Map<string, string[]> = new Map();
  // 각 checklist ID별로 마지막 데이터 저장 시간을 추적하기 위한 맵
  private checklistItemDate: Map<string, Date> = new Map();
  ```
### 부족한 부분
- 소켓에서 유저 검증
- 소켓 에러 처리
- 테스트 코드

## 스크린샷
- n/a

## 테스트 결과(커버리지/테스트 결과)
n/a