### PR TITLE
🔐feat: 개발용 임시로 액세스,리프레시 토큰들 만료기한 일주일로 설정

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -149,9 +149,11 @@ export class AuthService {
       userId: user.userId,
       tokenType,
     };
+    const ONE_WEEK = 7 * 24 * 60 * 60;
     return this.jwtService.sign(payload, {
       secret: process.env['JWT_SECRET'],
-      expiresIn: tokenType === 'access' ? 300 : 3600,
+      // expiresIn: tokenType === 'access' ? 300 : 3600,
+      expiresIn: tokenType === 'access' ? ONE_WEEK : ONE_WEEK,
     });
   }
 


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
closes #141  

## 고민과 해결 과정
- 개발할 떄 토큰이 너무 빨리 만료해서 테스트할 떄마다 로그인해야하는 귀찮음이 있다.
- 이제 앱이랑 연결하는데 앱에서 로그인을 계속 해야하니 번거로움이 있다.

## 스크린샷
![image](https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/1e35b2fd-440c-44c9-bb0a-f35dbc808db8)


## 테스트 결과(커버리지/테스트 결과)
- N/A