### PR TITLE
[Server] 공유 체크리스트 아이템 권한 문제 및 uuid 문제 해결

### DIFF
--- a/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
+++ b/server/src/shared-checklists/dto/create-shared-checklist.dto.ts
@@ -1,5 +1,5 @@
 import { PickType } from '@nestjs/mapped-types';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { SharedChecklistModel } from '../entities/shared-checklist.entity';
 
 export class CreateSharedChecklistDto extends PickType(SharedChecklistModel, [
@@ -13,8 +13,7 @@ export class CreateSharedChecklistDto extends PickType(SharedChecklistModel, [
   @IsNotEmpty()
   title: string;
 
-  @IsString()
-  @IsNotEmpty()
+  @IsUUID()
   sharedChecklistId: string;
 
   @IsNotEmpty()

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -27,6 +27,8 @@ export class SharedChecklistsService {
    * @returns 생성된 공유 체크리스트 객체
    */
   async createSharedChecklist(userId: number, dto: CreateSharedChecklistDto) {
+    // 사용자가 존재하는지 확인
+    const user = await this.usersService.findUserById(userId);
     // 중복된 sharedChecklistId가 있는지 확인
     const checklistExists = await this.SharedChecklistsrepository.exist({
       where: {
@@ -40,7 +42,7 @@ export class SharedChecklistsService {
     const newChecklist = this.SharedChecklistsrepository.create({
       title: dto.title,
       sharedChecklistId: dto.sharedChecklistId,
-      editors: [{ userId }],
+      editors: [user],
     });
     // Checklist 저장
     return this.SharedChecklistsrepository.save(newChecklist);

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -125,13 +125,19 @@ export class SharedChecklistsService {
   ) {
     const sharedChecklist =
       await this.findSharedChecklistById(sharedChecklistId);
-    if (!sharedChecklist.editors.some((editor) => editor.userId === userId)) {
+
+    const isEditor = sharedChecklist.editors.some(
+      (editor) => editor.userId === userId,
+    );
+    if (!isEditor) {
       throw new BadRequestException('권한이 없습니다.');
     }
+
     delete sharedChecklist.editors;
 
     const items = await this.findSharedChecklistItemsById(
       sharedChecklistId,
+      userId,
       date,
     );
     return { sharedChecklist, items };
@@ -150,6 +156,7 @@ export class SharedChecklistsService {
     if (!sharedChecklist) {
       throw new BadRequestException('존재하지 않는 체크리스트입니다.');
     }
+
     return sharedChecklist;
   }
 
@@ -159,7 +166,18 @@ export class SharedChecklistsService {
    * @param date 선택적 날짜 필터링 (이 날짜 이후의 아이템만 조회)
    * @returns 조회된 체크리스트 아이템 배열
    */
-  async findSharedChecklistItemsById(sharedChecklistId: string, date?: string) {
+  async findSharedChecklistItemsById(
+    sharedChecklistId: string,
+    userId: number,
+    date?: string,
+  ) {
+    // 체크리스트가 존재하는지, 권한이 있는지 확인
+    const sharedChecklist =
+      await this.findSharedChecklistById(sharedChecklistId);
+    if (!sharedChecklist.editors.some((editor) => editor.userId === userId)) {
+      throw new BadRequestException('권한이 없습니다.');
+    }
+
     const queryOptions = {
       where: { sharedChecklist: { sharedChecklistId } },
     };

--- a/server/src/shared-checklists/shared-checklists.service.ts
+++ b/server/src/shared-checklists/shared-checklists.service.ts
@@ -42,7 +42,7 @@ export class SharedChecklistsService {
     const newChecklist = this.SharedChecklistsrepository.create({
       title: dto.title,
       sharedChecklistId: dto.sharedChecklistId,
-      editors: [user],
+      editors: [{ userId }],
     });
     // Checklist 저장
     return this.SharedChecklistsrepository.save(newChecklist);
@@ -128,18 +128,13 @@ export class SharedChecklistsService {
     const sharedChecklist =
       await this.findSharedChecklistById(sharedChecklistId);
 
-    const isEditor = sharedChecklist.editors.some(
-      (editor) => editor.userId === userId,
-    );
-    if (!isEditor) {
+    if (!sharedChecklist.editors.some((editor) => editor.userId === userId)) {
       throw new BadRequestException('권한이 없습니다.');
     }
-
     delete sharedChecklist.editors;
 
     const items = await this.findSharedChecklistItemsById(
       sharedChecklistId,
-      userId,
       date,
     );
     return { sharedChecklist, items };
@@ -168,18 +163,7 @@ export class SharedChecklistsService {
    * @param date 선택적 날짜 필터링 (이 날짜 이후의 아이템만 조회)
    * @returns 조회된 체크리스트 아이템 배열
    */
-  async findSharedChecklistItemsById(
-    sharedChecklistId: string,
-    userId: number,
-    date?: string,
-  ) {
-    // 체크리스트가 존재하는지, 권한이 있는지 확인
-    const sharedChecklist =
-      await this.findSharedChecklistById(sharedChecklistId);
-    if (!sharedChecklist.editors.some((editor) => editor.userId === userId)) {
-      throw new BadRequestException('권한이 없습니다.');
-    }
-
+  async findSharedChecklistItemsById(sharedChecklistId: string, date?: string) {
     const queryOptions = {
       where: { sharedChecklist: { sharedChecklistId } },
     };


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #145 
- 위에는 착각으로 인한 오해로 사용자 검증만 추가함
- 공유체크리스트 생성시 id가 uuid가 아니면 서버 죽는 문제 해결

## 고민과 해결 과정
n/a

## 스크린샷
<img width="958" alt="스크린샷 2023-11-30 오후 5 44 52" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/ef8a0654-d3ea-4fca-8640-a8511a61710f">

## 테스트 결과(커버리지/테스트 결과)
n/a