### PR TITLE
[Server] 소켓 다중 서버 지원 

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -11,6 +11,14 @@ services:
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE}
+  redis:
+    image: redis
+    restart: always
+    ports:
+      - 6379:6379
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    command: redis-server --requirepass ${REDIS_PASSWORD}
 
   # nestjs_server:
   #   build: .

--- a/server/package.json
+++ b/server/package.json
@@ -40,6 +40,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "class-validator": "^0.14.0",
     "nest-winston": "^1.9.4",
     "pg": "^8.11.3",
+    "redis": "^4.6.11",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",

--- a/server/redis/redis.module.ts
+++ b/server/redis/redis.module.ts
@@ -1,0 +1,71 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { RedisClientType, createClient } from 'redis';
+
+/**
+ * RedisModule은 NestJS 애플리케이션에서 Redis 클라이언트를 설정하고 관리하는데 사용되는 모듈이다.
+ */
+@Global()
+@Module({})
+export class RedisModule {
+  /**
+   * forRoot 메서드는 Redis 클라이언트를 생성하고 초기화한다. 이 메서드는 DynamicModule을 반환한다.
+   */
+  static forRoot(): DynamicModule {
+    /**
+     * 일반적인 데이터 작업을 위한 Redis 클라이언트를 제공한다.
+     */
+    const redisProvider = {
+      provide: 'REDIS_CLIENT',
+      useFactory: async (): Promise<RedisClientType> => {
+        const client = createClient({
+          url: process.env.REDIS_URL, // Redis 서버의 URL
+          username: process.env.REDIS_USERNAME, // Redis 사용자 이름
+          password: process.env.REDIS_PASSWORD, // Redis 비밀번호
+        }) as RedisClientType;
+        await client.connect(); // 클라이언트 연결
+        return client; // 연결된 클라이언트 반환
+      },
+    };
+
+    /**
+     * 메시지를 Redis 채널에 게시하는 데 사용되는 Redis 클라이언트를 제공한다.
+     */
+    const redisPubProvider = {
+      provide: 'REDIS_PUB_CLIENT',
+      useFactory: async (): Promise<RedisClientType> => {
+        const client = createClient({
+          url: process.env.REDIS_URL,
+          username: process.env.REDIS_USERNAME,
+          password: process.env.REDIS_PASSWORD,
+        }) as RedisClientType;
+        await client.connect();
+        return client;
+      },
+    };
+
+    /**
+     * Redis 채널에서 메시지를 수신하는 데 사용되는 Redis 클라이언트를 제공한다.
+     */
+    const redisSubProvider = {
+      provide: 'REDIS_SUB_CLIENT',
+      useFactory: async (): Promise<RedisClientType> => {
+        const client = createClient({
+          url: process.env.REDIS_URL,
+          username: process.env.REDIS_USERNAME,
+          password: process.env.REDIS_PASSWORD,
+        }) as RedisClientType;
+        await client.connect();
+        return client;
+      },
+    };
+
+    /**
+     * 모듈 구성을 반환한다. 여기에는 Redis 클라이언트 및 해당 클라이언트를 다른 모듈에서 주입하여 사용할 수 있도록 하는 설정이 포함되어 있다.
+     */
+    return {
+      module: RedisModule,
+      providers: [redisProvider, redisPubProvider, redisSubProvider],
+      exports: [redisProvider, redisPubProvider, redisSubProvider],
+    };
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,6 +7,7 @@ import {
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WinstonModule } from 'nest-winston';
+import { RedisModule } from 'redis/redis.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
@@ -31,6 +32,7 @@ import { winstonConfig } from './utils/winston.config';
       envFilePath: '.env',
       isGlobal: true,
     }),
+    RedisModule.forRoot(),
     TypeOrmModule.forRoot({
       type: 'postgres',
       host: process.env['DB_HOST'],

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -23,6 +23,9 @@ async function bootstrap() {
   );
   app.useWebSocketAdapter(new WsAdapter(app));
 
-  await app.listen(3000);
+  const port = process.env.PORT || 3000; // 환경 변수에서 포트를 가져오거나 기본값으로 3000 사용
+  await app.listen(port);
+  console.log(`Application is running on: ${await app.getUrl()}`);
 }
+
 bootstrap();

--- a/server/src/shared-checklists/shared-checklists.gateway.ts
+++ b/server/src/shared-checklists/shared-checklists.gateway.ts
@@ -1,3 +1,4 @@
+import { Inject } from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
@@ -7,6 +8,7 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import { RedisClientType } from 'redis';
 import { parse } from 'url';
 import * as WebSocket from 'ws';
 import { SharedChecklistsService } from './shared-checklists.service';
@@ -20,6 +22,11 @@ export class SharedChecklistsGateway
 {
   constructor(
     private readonly sharedChecklistsService: SharedChecklistsService,
+    @Inject('REDIS_CLIENT') private readonly redisClient: RedisClientType,
+    @Inject('REDIS_PUB_CLIENT')
+    private readonly redisPublisher: RedisClientType,
+    @Inject('REDIS_SUB_CLIENT')
+    private readonly redisSubscriber: RedisClientType,
   ) {}
   @WebSocketServer() server: WebSocket.Server;
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5570,7 +5570,7 @@ uuid@9.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -884,6 +884,40 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.5.12":
+  version "1.5.12"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-1.5.12.tgz#4c387727992152aea443b869de0ebb697f899187"
+  integrity sha512-/ZjE18HRzMd80eXIIUIPcH81UoZpwulbo8FmbElrjPqH0QC0SeIKu1BOU49bO5trM5g895kAjhvalt5h77q+4A==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@redis/graph/-/graph-1.1.1.tgz#8c10df2df7f7d02741866751764031a957a170ea"
+  integrity sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==
+
+"@redis/json@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-1.0.6.tgz#b7a7725bbb907765d84c99d55eac3fcf772e180e"
+  integrity sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==
+
+"@redis/search@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-1.1.6.tgz#33bcdd791d9ed88ab6910243a355d85a7fedf756"
+  integrity sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==
+
+"@redis/time-series@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-1.0.5.tgz#a6d70ef7a0e71e083ea09b967df0a0ed742bc6ad"
+  integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1959,6 +1993,11 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2845,6 +2884,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -4745,6 +4789,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+redis@^4.6.11:
+  version "4.6.11"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-4.6.11.tgz#fad85e104545228f212259fd557c3e4f8eafcd3d"
+  integrity sha512-kg1Lt4NZLYkAjPOj/WcyIGWfZfnyfKo1Wg9YKVSlzhFwxpFIl3LYI8BWy1Ab963LLDsTz2+OwdsesHKljB3WMQ==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.5.12"
+    "@redis/graph" "1.1.1"
+    "@redis/json" "1.0.6"
+    "@redis/search" "1.1.6"
+    "@redis/time-series" "1.0.5"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -5723,15 +5779,15 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
+yallist@4.0.0, yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #157 

## 고민과 해결 과정
### 레디스를 어떻게 연결 및 사용할까?
- 도커와 커스텀 모듈을 이용해 만들었다.
- ```yaml
  redis:
    image: redis
    restart: always
    ports:
      - 6379:6379
    environment:
      REDIS_PASSWORD: ${REDIS_PASSWORD}
    command: redis-server --requirepass ${REDIS_PASSWORD}
  ```
- ```ts
    const redisProvider = {
      provide: 'REDIS_CLIENT',
      useFactory: async (): Promise<RedisClientType> => {
        const client = createClient({
          url: process.env.REDIS_URL, // Redis 서버의 URL
          username: process.env.REDIS_USERNAME, // Redis 사용자 이름
          password: process.env.REDIS_PASSWORD, // Redis 비밀번호
        }) as RedisClientType;
        await client.connect(); // 클라이언트 연결
        return client; // 연결된 클라이언트 반환
      },
    };
  ```
### 다른 서버의 소켓과 어떻게 통신하지?
- 레디스의 pub/sub을 이용해 해결했다.
- 한 소켓에서 메시지를 보내면 해당 메시지를 pub한다.
- 그럼 다른 서버가 해당 메시지를 sub 한 뒤 해당 메시지를 토대로 자기 서버에 broadcast를 해준다.
- ```ts
    // 전송시
    this.redisPublisher.publish('sharedChecklist', message);
    // 구독시
    this.redisSubscriber.subscribe('sharedChecklist', (message) => {
      const { serverUuid, sharedChecklistId, data } = JSON.parse(message);
     // 자기가 아닌 다른 서버에서 온 메시지면 지기 소켓들에게 브로드케스트
      if (serverUuid !== this.serverUuid) {
        this.broadcastToLocal(sharedChecklistId, 'listen', data);
      }
    });
  ```

### 히스토리를 어떻게 하지?
- 기존에는 맵 자료형을 이용해 로컬에서 저장했다.
- 이를 레디스의 lists 자료형으로 변경하였다.
- ```ts
    // 저장시
    const redisArrayKey = `sharedChecklistHistory:${sharedChecklistId}`;
    this.redisClient.rPush(redisArrayKey, data);
    // 누적 데이터 보내주기
    const redisArrayKey = `sharedChecklistHistory:${sharedChecklistId}`;
    const history = await this.redisClient.lRange(redisArrayKey, 0, -1);
    if (history.length > 0) {
      this.sendToClient(client, 'history', history);
    }
  ```

### 방의 모든 사용자가 접속을 종료한 것을 어떻게 알지?
- 레디스의 string의 INCR,DECR를 이용해 접속/ 접속 해지 할 때 마다 해당 방마다 카운트를 기록했다.
- ```ts
    // 접속/ 접속 해지 할 때 마다 방 카운트 기록
    const redisCountKey = `sharedChecklistCount:${sharedChecklistId}`;
    if (isConnecting) {
      await this.redisClient.INCR(redisCountKey);
    } else {
      await this.redisClient.DECR(redisCountKey);
    }
    return parseInt(await this.redisClient.GET(redisCountKey), 10);
    // 모든 유저가 방을 나가면 히스토리  데이터베이스에 저장 후 레디스 데이터 비우기
    const count = await this.updateRedisCount(sharedChecklistId, false);
    if (count === 0) {
          const redisArrayKey = `sharedChecklistHistory:${sharedChecklistId}`;
          const history = await this.redisClient.lRange(redisArrayKey, 0, -1);
          if (history.length > 0) {
            await this.saveToDatabase(sharedChecklistId, history);
            await this.redisClient.del(redisArrayKey);
          }
    }
  ```
 

## 스크린샷

- 다중 서버 끼리도 잘 통신이 된다.
- 3000과 3001 잘 통신이 된다.
- <img width="1010" alt="스크린샷 2023-12-04 오전 12 03 38" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/1dd3f349-545e-4a44-b784-a00c7415012b">
- <img width="1013" alt="스크린샷 2023-12-04 오전 12 03 45" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/521fde8d-9eb6-4d86-b239-4da1d785ad6e">
- <img width="1021" alt="스크린샷 2023-12-04 오전 12 03 54" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/0f990937-5914-43df-8bf4-88e3a39f33cb">
- <img width="1013" alt="스크린샷 2023-12-04 오전 12 04 02" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/51476641/5c3f23b4-d92c-4b71-9ab6-2f73689656a1">

## 테스트 결과(커버리지/테스트 결과)
n/a