### PR TITLE
[Server] 로거 기능 확대

### DIFF
--- a/server/redis/redis.module.ts
+++ b/server/redis/redis.module.ts
@@ -20,7 +20,7 @@ export class RedisModule {
         const client = createClient({
           url: process.env.REDIS_URL, // Redis 서버의 URL
           // username: process.env.REDIS_USERNAME, // Redis 사용자 이름
-          // password: process.env.REDIS_PASSWORD, // Redis 비밀번호
+          password: process.env.REDIS_PASSWORD, // Redis 비밀번호
         }) as RedisClientType;
         await client.connect(); // 클라이언트 연결
         return client; // 연결된 클라이언트 반환
@@ -36,7 +36,7 @@ export class RedisModule {
         const client = createClient({
           url: process.env.REDIS_URL,
           // username: process.env.REDIS_USERNAME,
-          // password: process.env.REDIS_PASSWORD,
+          password: process.env.REDIS_PASSWORD,
         }) as RedisClientType;
         await client.connect();
         return client;
@@ -52,7 +52,7 @@ export class RedisModule {
         const client = createClient({
           url: process.env.REDIS_URL,
           // username: process.env.REDIS_USERNAME,
-          // password: process.env.REDIS_PASSWORD,
+          password: process.env.REDIS_PASSWORD,
         }) as RedisClientType;
         await client.connect();
         return client;

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -25,6 +25,8 @@ import { SharedChecklistsModule } from './shared-checklists/shared-checklists.mo
 import { UserModel } from './users/entities/user.entity';
 import { UsersModule } from './users/users.module';
 import { winstonConfig } from './utils/winston.config';
+import { LoggingInterceptor } from './common/interceptor/log.interceptor';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -60,7 +62,13 @@ import { winstonConfig } from './utils/winston.config';
     CategoriesModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: LoggingInterceptor,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/server/src/common/interceptor/log.interceptor.ts
+++ b/server/src/common/interceptor/log.interceptor.ts
@@ -1,0 +1,42 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { WinstonModule } from 'nest-winston';
+import { winstonConfig } from '../../utils/winston.config';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = WinstonModule.createLogger(winstonConfig);
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const ctx = context.switchToHttp();
+    const request = ctx.getRequest();
+    const response = ctx.getResponse();
+    const startTime = request['startTime'];
+    const reqBody = request['reqBody'];
+
+    return next.handle().pipe(
+      tap((data) => {
+        const endTime = Date.now();
+        const duration = endTime - startTime;
+        const { method, originalUrl, ip } = request;
+        const { statusCode } = response;
+        const startTimeString = new Date(startTime).toLocaleString('ko-KR', {
+          timeZone: 'Asia/Seoul',
+        });
+
+        this.logger.log({
+          level: 'info',
+          message: `${startTimeString} - ${method} ${originalUrl} - Status: ${statusCode} - IP: ${ip} - Duration: ${duration}ms - Request Body: ${JSON.stringify(
+            reqBody,
+          )} - Response Body: ${JSON.stringify(data)}`,
+        });
+      }),
+    );
+  }
+}

--- a/server/src/common/middlewares/logger.middleware.ts
+++ b/server/src/common/middlewares/logger.middleware.ts
@@ -8,16 +8,19 @@ export class LoggerMiddleware implements NestMiddleware {
   private readonly logger = WinstonModule.createLogger(winstonConfig);
 
   use(req: Request, res: Response, next: NextFunction) {
-    const startTime = Date.now(); // 요청 시작 시간 기록
+    const startTime = new Date(); // 현재 시간을 Date 객체로 얻기
+    const startTimeString = startTime.toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+    }); // 한국 시간대로 변환
     const { ip, method, originalUrl } = req;
     const userAgent = req.get('user-agent');
 
     res.on('finish', () => {
-      const duration = Date.now() - startTime; // 요청 처리 시간 계산
+      const duration = Date.now() - startTime.getTime(); // 요청 처리 시간 계산
       const { statusCode } = res;
       this.logger.log({
         level: 'info',
-        message: `${method} ${originalUrl} ${statusCode} ${ip} ${userAgent} - ${duration}ms`,
+        message: `${startTimeString} - ${method} ${originalUrl} ${statusCode} ${ip} ${userAgent} - ${duration}ms`,
       });
     });
 

--- a/server/src/common/middlewares/logger.middleware.ts
+++ b/server/src/common/middlewares/logger.middleware.ts
@@ -8,21 +8,9 @@ export class LoggerMiddleware implements NestMiddleware {
   private readonly logger = WinstonModule.createLogger(winstonConfig);
 
   use(req: Request, res: Response, next: NextFunction) {
-    const startTime = new Date(); // 현재 시간을 Date 객체로 얻기
-    const startTimeString = startTime.toLocaleString('ko-KR', {
-      timeZone: 'Asia/Seoul',
-    }); // 한국 시간대로 변환
-    const { ip, method, originalUrl } = req;
-    const userAgent = req.get('user-agent');
-
-    res.on('finish', () => {
-      const duration = Date.now() - startTime.getTime(); // 요청 처리 시간 계산
-      const { statusCode } = res;
-      this.logger.log({
-        level: 'info',
-        message: `${startTimeString} - ${method} ${originalUrl} ${statusCode} ${ip} ${userAgent} - ${duration}ms`,
-      });
-    });
+    const startTime = Date.now(); // 요청 시작 시간을 현재 시간으로 설정
+    req['startTime'] = startTime; // startTime을 req 객체에 저장
+    req['reqBody'] = req.body; // 요청 본문을 req 객체에 저장
 
     next();
   }

--- a/server/src/utils/winston.config.ts
+++ b/server/src/utils/winston.config.ts
@@ -3,7 +3,7 @@ import * as winstonDaily from 'winston-daily-rotate-file';
 import * as winston from 'winston';
 
 const env = process.env.NODE_ENV;
-const logDir = __dirname + '/../../logs'; // log 파일을 관리할 폴더
+const logDir = __dirname + '/../../../logs'; // log 파일을 관리할 폴더
 
 const dailyOptions = (level: string) => {
   return {


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
- Close #173 

<br>

## 💡 고민과 해결 과정
### `배경`
![image](https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/1737df83-71f8-455e-ba94-b8b663058652)

### `고민`
- reponse body를 로깅해야하는데 미들웨어에서 응답 본문을 기록하려면 응답 객체를 래핑(wrap)하여 기록할 수 있는 형태로 만들어야 한다. 먼저, 응답 객체에 대한 참조를 만들고, 그 참조에 데이터를 기록한 다음, 원래의 응답 객체로 데이터를 전달하는 방식으로 구현할 수 있는데, 조금 복잡하다.
### `해결과정`
- response에 대해서는 interceptor를 사용하였다.
```ts
@Injectable()
export class LoggerMiddleware implements NestMiddleware {
  private readonly logger = WinstonModule.createLogger(winstonConfig);

  use(req: Request, res: Response, next: NextFunction) {
    const startTime = Date.now(); // 요청 시작 시간을 현재 시간으로 설정
    req['startTime'] = startTime; // startTime을 req 객체에 저장
    req['reqBody'] = req.body; // 요청 본문을 req 객체에 저장

    next();
  }
}
```
- req에 요청 처리 시작시간과 요청 body를 넘긴다.
```ts
@Injectable()
export class LoggingInterceptor implements NestInterceptor {
  private readonly logger = WinstonModule.createLogger(winstonConfig);

  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
    const ctx = context.switchToHttp();
    const request = ctx.getRequest();
    const response = ctx.getResponse();
    const startTime = request['startTime'];
    const reqBody = request['reqBody'];

    return next.handle().pipe(
      tap((data) => {
        const endTime = Date.now();
        const duration = endTime - startTime;
        const { method, originalUrl, ip } = request;
        const { statusCode } = response;
        const startTimeString = new Date(startTime).toLocaleString('ko-KR', {
          timeZone: 'Asia/Seoul',
        });

        this.logger.log({
          level: 'info',
          message: `${startTimeString} - ${method} ${originalUrl} - Status: ${statusCode} - IP: ${ip} - Duration: ${duration}ms - Request Body: ${JSON.stringify(
            reqBody,
          )} - Response Body: ${JSON.stringify(data)}`,
        });
      }),
    );
  }
}
```
- interceptor에서 이것들을 받아와서 현재 시간에 요청 처리시간을 빼 소요된 시간과 함께, 요청 본문, 응답 본문, 기타 정보들을 로그 파일에 저장하고, 콘솔에 찍는다.
<br>

## 📸 스크린샷
- 콘솔
![image](https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/9cf78e51-35ce-490e-95f8-cb78d06efe8c)

- 로그파일
![image](https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/2bc48944-c52a-40f6-b8e8-83209a28f4a7)

<br>

## ✅ 테스트 결과(커버리지/테스트 결과)
N/A