### PR TITLE
설정 화면 구현

### DIFF
--- a/client/Projects/OpenList/OpenList.xcodeproj/project.pbxproj
+++ b/client/Projects/OpenList/OpenList.xcodeproj/project.pbxproj
@@ -68,6 +68,15 @@
 		4DDC43422B0F2AC000859B28 /* CRDTStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDC43412B0F2AC000859B28 /* CRDTStorage.swift */; };
 		4DDC43492B0F39EB00859B28 /* DefaultCRDTStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDC43482B0F39EB00859B28 /* DefaultCRDTStorage.swift */; };
 		4DDC434B2B0F432900859B28 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDC434A2B0F432900859B28 /* Device.swift */; };
+		4DF0D5392B1E0F1000EC68CA /* SettingAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5342B1E0F1000EC68CA /* SettingAction.swift */; };
+		4DF0D53A2B1E0F1000EC68CA /* SettingRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5352B1E0F1000EC68CA /* SettingRouter.swift */; };
+		4DF0D53B2B1E0F1000EC68CA /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5362B1E0F1000EC68CA /* SettingViewController.swift */; };
+		4DF0D53C2B1E0F1000EC68CA /* SettingViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5372B1E0F1000EC68CA /* SettingViewFactory.swift */; };
+		4DF0D53D2B1E0F1000EC68CA /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5382B1E0F1000EC68CA /* SettingViewModel.swift */; };
+		4DF0D5402B1E0FFC00EC68CA /* SettingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D53F2B1E0FFC00EC68CA /* SettingItem.swift */; };
+		4DF0D5432B1E133800EC68CA /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5422B1E133800EC68CA /* SettingTableViewCell.swift */; };
+		4DF0D5452B1E1B5400EC68CA /* CheckListTabRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5442B1E1B5400EC68CA /* CheckListTabRouter.swift */; };
+		4DF0D54B2B1E233100EC68CA /* TitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D54A2B1E233100EC68CA /* TitleHeaderView.swift */; };
 		5F70C8302B04A96E00826B5D /* PrivateDetailCheckListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82B2B04A96E00826B5D /* PrivateDetailCheckListViewController.swift */; };
 		5F70C8312B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82C2B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift */; };
 		5F70C8322B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82D2B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift */; };
@@ -278,6 +287,15 @@
 		4DDC43412B0F2AC000859B28 /* CRDTStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRDTStorage.swift; sourceTree = "<group>"; };
 		4DDC43482B0F39EB00859B28 /* DefaultCRDTStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCRDTStorage.swift; sourceTree = "<group>"; };
 		4DDC434A2B0F432900859B28 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		4DF0D5342B1E0F1000EC68CA /* SettingAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAction.swift; sourceTree = "<group>"; };
+		4DF0D5352B1E0F1000EC68CA /* SettingRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingRouter.swift; sourceTree = "<group>"; };
+		4DF0D5362B1E0F1000EC68CA /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		4DF0D5372B1E0F1000EC68CA /* SettingViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewFactory.swift; sourceTree = "<group>"; };
+		4DF0D5382B1E0F1000EC68CA /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		4DF0D53F2B1E0FFC00EC68CA /* SettingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingItem.swift; sourceTree = "<group>"; };
+		4DF0D5422B1E133800EC68CA /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		4DF0D5442B1E1B5400EC68CA /* CheckListTabRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListTabRouter.swift; sourceTree = "<group>"; };
+		4DF0D54A2B1E233100EC68CA /* TitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderView.swift; sourceTree = "<group>"; };
 		5F70C82B2B04A96E00826B5D /* PrivateDetailCheckListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewController.swift; sourceTree = "<group>"; };
 		5F70C82C2B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewFactory.swift; sourceTree = "<group>"; };
 		5F70C82D2B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewModel.swift; sourceTree = "<group>"; };
@@ -623,6 +641,7 @@
 				5F8F5FEA2B186D58001F7978 /* User.swift */,
 				4D42B8A72B1C42D900ACE359 /* TextChange.swift */,
 				4D42B8AC2B1C9A3B00ACE359 /* Comparison.swift */,
+				4DF0D53F2B1E0FFC00EC68CA /* SettingItem.swift */,
 			);
 			path = Entites;
 			sourceTree = "<group>";
@@ -657,6 +676,44 @@
 				4DDC43482B0F39EB00859B28 /* DefaultCRDTStorage.swift */,
 			);
 			path = CRDTStorage;
+			sourceTree = "<group>";
+		};
+		4DF0D5312B1E0EC900EC68CA /* NavigationScene */ = {
+			isa = PBXGroup;
+			children = (
+				4DF0D5492B1E232800EC68CA /* Common */,
+				4DF0D5322B1E0ED500EC68CA /* SettingScene */,
+			);
+			path = NavigationScene;
+			sourceTree = "<group>";
+		};
+		4DF0D5322B1E0ED500EC68CA /* SettingScene */ = {
+			isa = PBXGroup;
+			children = (
+				4DF0D5412B1E12C300EC68CA /* View */,
+				4DF0D5342B1E0F1000EC68CA /* SettingAction.swift */,
+				4DF0D5352B1E0F1000EC68CA /* SettingRouter.swift */,
+				4DF0D5362B1E0F1000EC68CA /* SettingViewController.swift */,
+				4DF0D5372B1E0F1000EC68CA /* SettingViewFactory.swift */,
+				4DF0D5382B1E0F1000EC68CA /* SettingViewModel.swift */,
+			);
+			path = SettingScene;
+			sourceTree = "<group>";
+		};
+		4DF0D5412B1E12C300EC68CA /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4DF0D5422B1E133800EC68CA /* SettingTableViewCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		4DF0D5492B1E232800EC68CA /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				4DF0D54A2B1E233100EC68CA /* TitleHeaderView.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		5F70C8282B04A93A00826B5D /* PrivateDetailCheckListScene */ = {
@@ -821,6 +878,7 @@
 		5FA1F89A2AFF7E1600869079 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				4DF0D5312B1E0EC900EC68CA /* NavigationScene */,
 				78A4C7142B0F2ECC00E07492 /* LoginScene */,
 				5FA1F8C02AFF801600869079 /* TabbarScene */,
 			);
@@ -917,6 +975,7 @@
 				5F9349072B16DF4D00282545 /* CheckListTabViewController.swift */,
 				5F9349082B16DF4D00282545 /* CheckListTabViewFactory.swift */,
 				5F9349092B16DF4D00282545 /* CheckListTopTabView.swift */,
+				4DF0D5442B1E1B5400EC68CA /* CheckListTabRouter.swift */,
 				4DDC43342B0F172100859B28 /* DetailScene */,
 				5F93490D2B16DF5500282545 /* CheckListFolderScene */,
 				4D3398022B023BE800963664 /* CheckListTableScene */,
@@ -1236,10 +1295,13 @@
 				78A4C71A2B0F2ED900E07492 /* LoginAction.swift in Sources */,
 				4DCF10F02B10EC4300C614B7 /* LinkedList.swift in Sources */,
 				78E9560A2B16FC23005CF5D3 /* AddCheckListTitleViewModel.swift in Sources */,
+				4DF0D5392B1E0F1000EC68CA /* SettingAction.swift in Sources */,
 				5F9349182B16DF5500282545 /* CheckListFolderViewModel.swift in Sources */,
 				4DDC433E2B0F2A3D00859B28 /* DefaultCRDTRepository.swift in Sources */,
 				5FA1F8B62AFF7FBB00869079 /* Dependency.swift in Sources */,
+				4DF0D53C2B1E0F1000EC68CA /* SettingViewFactory.swift in Sources */,
 				78A4C72B2B0F5FB100E07492 /* AuthRepository.swift in Sources */,
+				4DF0D54B2B1E233100EC68CA /* TitleHeaderView.swift in Sources */,
 				78C2F00F2B048B6C00E4EC4E /* TabBarViewController.swift in Sources */,
 				78C2F0222B049A8A00E4EC4E /* PersistenceUseCase.swift in Sources */,
 				4D3415582B183303004C3FC9 /* WithCheckListResponseDTO.swift in Sources */,
@@ -1252,6 +1314,7 @@
 				78E956072B16FC23005CF5D3 /* SubCategoryRouter.swift in Sources */,
 				78E9560C2B16FC23005CF5D3 /* AddCheckListTitleRouter.swift in Sources */,
 				5FA1F8D32AFF802900869079 /* TabBarPage.swift in Sources */,
+				4DF0D5432B1E133800EC68CA /* SettingTableViewCell.swift in Sources */,
 				5F9349062B16DF4600282545 /* SharedCheckListViewModel.swift in Sources */,
 				4D36A39B2B177B73009AA063 /* AddCheckListItemHeaderView.swift in Sources */,
 				5FA1F8B42AFF7FBB00869079 /* ViewControllable.swift in Sources */,
@@ -1268,6 +1331,7 @@
 				4D967CF12B05AF940032E0D7 /* CoreDataStorage.swift in Sources */,
 				78E956042B16FC23005CF5D3 /* SubCategoryViewFactory.swift in Sources */,
 				78A4C7252B0F5C6900E07492 /* AuthUseCase.swift in Sources */,
+				4DF0D5452B1E1B5400EC68CA /* CheckListTabRouter.swift in Sources */,
 				78E9561A2B171F4D005CF5D3 /* CategoryInfo.swift in Sources */,
 				5F93491E2B16DFF300282545 /* UICollectionView+Extensions.swift in Sources */,
 				4D36A3902B177167009AA063 /* AddCheckListItemViewController.swift in Sources */,
@@ -1278,6 +1342,7 @@
 				4D8AEBD82B121F3A00292AF3 /* WithCheckListItem.swift in Sources */,
 				78C2F00A2B0487B400E4EC4E /* UITextField+Combine.swift in Sources */,
 				5F9349042B16DF4600282545 /* SharedCheckListCell.swift in Sources */,
+				4DF0D53B2B1E0F1000EC68CA /* SettingViewController.swift in Sources */,
 				5F70C83B2B04BF9A00826B5D /* CheckListItemButton.swift in Sources */,
 				4DDC432F2B0F16CC00859B28 /* WithDetailCheckListAction.swift in Sources */,
 				78E956152B171973005CF5D3 /* MinorCategoryRouter.swift in Sources */,
@@ -1296,6 +1361,7 @@
 				78A4C71B2B0F2ED900E07492 /* LoginRouter.swift in Sources */,
 				78E956002B16FC23005CF5D3 /* CategoryHeaderView.swift in Sources */,
 				4D3398082B023BE800963664 /* CheckListTableAction.swift in Sources */,
+				4DF0D53D2B1E0F1000EC68CA /* SettingViewModel.swift in Sources */,
 				5F8F5FDE2B1844D7001F7978 /* WithCheckListViewFactory.swift in Sources */,
 				4D36A39F2B178B65009AA063 /* AddCheckListItemPlaceholder.swift in Sources */,
 				5F70C83D2B04C39F00826B5D /* CheckListItemTextField.swift in Sources */,
@@ -1328,6 +1394,8 @@
 				78E956052B16FC23005CF5D3 /* SubCategoryViewController.swift in Sources */,
 				5FCCA3C12B104ABF00496EB2 /* OpenListNavigationBar.swift in Sources */,
 				5F8F5FEB2B186D58001F7978 /* User.swift in Sources */,
+				4DF0D53A2B1E0F1000EC68CA /* SettingRouter.swift in Sources */,
+				4DF0D5402B1E0FFC00EC68CA /* SettingItem.swift in Sources */,
 				5F70C8392B04BF7A00826B5D /* LocalCheckListItem.swift in Sources */,
 				5F9349022B16DF4600282545 /* SharedCheckListViewController.swift in Sources */,
 				5FA8466B2B10A08B00B90F85 /* UIDevice+safeAreaHeight.swift in Sources */,

--- a/client/Projects/OpenList/OpenList.xcodeproj/project.pbxproj
+++ b/client/Projects/OpenList/OpenList.xcodeproj/project.pbxproj
@@ -77,6 +77,9 @@
 		4DF0D5432B1E133800EC68CA /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5422B1E133800EC68CA /* SettingTableViewCell.swift */; };
 		4DF0D5452B1E1B5400EC68CA /* CheckListTabRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5442B1E1B5400EC68CA /* CheckListTabRouter.swift */; };
 		4DF0D54B2B1E233100EC68CA /* TitleHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D54A2B1E233100EC68CA /* TitleHeaderView.swift */; };
+		4DF0D54D2B1EBBF200EC68CA /* SettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D54C2B1EBBF200EC68CA /* SettingUseCase.swift */; };
+		4DF0D54F2B1EBC1700EC68CA /* SettingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D54E2B1EBC1700EC68CA /* SettingRepository.swift */; };
+		4DF0D5512B1EBC3A00EC68CA /* DefaultSettingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF0D5502B1EBC3A00EC68CA /* DefaultSettingRepository.swift */; };
 		5F70C8302B04A96E00826B5D /* PrivateDetailCheckListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82B2B04A96E00826B5D /* PrivateDetailCheckListViewController.swift */; };
 		5F70C8312B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82C2B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift */; };
 		5F70C8322B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F70C82D2B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift */; };
@@ -296,6 +299,9 @@
 		4DF0D5422B1E133800EC68CA /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
 		4DF0D5442B1E1B5400EC68CA /* CheckListTabRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListTabRouter.swift; sourceTree = "<group>"; };
 		4DF0D54A2B1E233100EC68CA /* TitleHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderView.swift; sourceTree = "<group>"; };
+		4DF0D54C2B1EBBF200EC68CA /* SettingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingUseCase.swift; sourceTree = "<group>"; };
+		4DF0D54E2B1EBC1700EC68CA /* SettingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingRepository.swift; sourceTree = "<group>"; };
+		4DF0D5502B1EBC3A00EC68CA /* DefaultSettingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingRepository.swift; sourceTree = "<group>"; };
 		5F70C82B2B04A96E00826B5D /* PrivateDetailCheckListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewController.swift; sourceTree = "<group>"; };
 		5F70C82C2B04A96E00826B5D /* PrivateDetailCheckListViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewFactory.swift; sourceTree = "<group>"; };
 		5F70C82D2B04A96E00826B5D /* PrivateDetailCheckListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDetailCheckListViewModel.swift; sourceTree = "<group>"; };
@@ -560,6 +566,7 @@
 				4DDC433D2B0F2A3D00859B28 /* DefaultCRDTRepository.swift */,
 				5F8F5FE62B18512D001F7978 /* DefaultWithCheckListRepository.swift */,
 				78E9561F2B178365005CF5D3 /* DefaultCategoryRepository.swift */,
+				4DF0D5502B1EBC3A00EC68CA /* DefaultSettingRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -928,6 +935,7 @@
 				4DDC43282B0F10EF00859B28 /* CRDTRepository.swift */,
 				5F8F5FE02B184D1D001F7978 /* WithCheckListRepository.swift */,
 				78E9561D2B17810C005CF5D3 /* CategoryRepository.swift */,
+				4DF0D54E2B1EBC1700EC68CA /* SettingRepository.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -942,6 +950,7 @@
 				4DD97D9B2B14D3A600DF73BC /* DetailCheckListUseCase.swift */,
 				4D34154F2B182F5D004C3FC9 /* WithCheckListUseCase.swift */,
 				78E9561B2B177DAB005CF5D3 /* CategoryUseCase.swift */,
+				4DF0D54C2B1EBBF200EC68CA /* SettingUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1347,6 +1356,7 @@
 				4DDC432F2B0F16CC00859B28 /* WithDetailCheckListAction.swift in Sources */,
 				78E956152B171973005CF5D3 /* MinorCategoryRouter.swift in Sources */,
 				5F9349212B16E03400282545 /* PrivateDetailCheckListAction.swift in Sources */,
+				4DF0D5512B1EBC3A00EC68CA /* DefaultSettingRepository.swift in Sources */,
 				5F9349172B16DF5500282545 /* CheckListFolderCell.swift in Sources */,
 				5F70C8462B05DC5100826B5D /* CheckListHeaderView.swift in Sources */,
 				4D36A3942B17755E009AA063 /* AddCheckListItemDiffableDataSource.swift in Sources */,
@@ -1365,6 +1375,7 @@
 				5F8F5FDE2B1844D7001F7978 /* WithCheckListViewFactory.swift in Sources */,
 				4D36A39F2B178B65009AA063 /* AddCheckListItemPlaceholder.swift in Sources */,
 				5F70C83D2B04C39F00826B5D /* CheckListItemTextField.swift in Sources */,
+				4DF0D54D2B1EBBF200EC68CA /* SettingUseCase.swift in Sources */,
 				4D967CD42B050EA60032E0D7 /* UIFont+.swift in Sources */,
 				78E956282B1795CC005CF5D3 /* RecommendChecklistItem.swift in Sources */,
 				78E956012B16FC23005CF5D3 /* CategoryProgressView.swift in Sources */,
@@ -1416,6 +1427,7 @@
 				4DD97D982B14934000DF73BC /* DeepLinkTarget.swift in Sources */,
 				4D36A3972B1777C3009AA063 /* AiCheckListCell.swift in Sources */,
 				4D36A38F2B177167009AA063 /* AddCheckListItemRouter.swift in Sources */,
+				4DF0D54F2B1EBC1700EC68CA /* SettingRepository.swift in Sources */,
 				4D967D152B0601870032E0D7 /* PrivateCheckListStorage.swift in Sources */,
 				5F9349012B16DF4600282545 /* SharedCheckListAction.swift in Sources */,
 				5F9349152B16DF5500282545 /* CheckListFolderViewFactory.swift in Sources */,

--- a/client/Projects/OpenList/OpenList/App/AppRouter.swift
+++ b/client/Projects/OpenList/OpenList/App/AppRouter.swift
@@ -28,7 +28,7 @@ final class AppRouter: AppRouterProtocol {
 	}
 	
 	func showTapFlow() {
-		let tabBarController = tabBarFactoryable.make()
+		let tabBarController = tabBarFactoryable.make(with: self)
 		self.window?.rootViewController = tabBarController.uiviewController
 	}
 	

--- a/client/Projects/OpenList/OpenList/Data/Repositories/DefaultSettingRepository.swift
+++ b/client/Projects/OpenList/OpenList/Data/Repositories/DefaultSettingRepository.swift
@@ -1,0 +1,42 @@
+//
+//  DefaultSettingRepository.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/5/23.
+//
+
+import CustomNetwork
+import Foundation
+
+final class DefaultSettingRepository {
+	private let checkListStorage: PrivateCheckListStorage
+	private let session: CustomSession
+	
+	init(
+		checkListStorage: PrivateCheckListStorage,
+		session: CustomSession
+	) {
+		self.checkListStorage = checkListStorage
+		self.session = session
+	}
+}
+
+extension DefaultSettingRepository: SettingRepository {
+	func logOut() async throws {
+		deleteToken()
+		// API Call
+	}
+	
+	func deleteAccount() async throws {
+		deleteToken()
+		try checkListStorage.removeAllCheckList()
+		// API Call
+	}
+}
+
+private extension DefaultSettingRepository {
+	func deleteToken() {
+		KeyChain.shared.delete(key: AuthKey.accessToken)
+		KeyChain.shared.delete(key: AuthKey.refreshToken)
+	}
+}

--- a/client/Projects/OpenList/OpenList/Data/Storages/PrivateCheckListStorage.swift
+++ b/client/Projects/OpenList/OpenList/Data/Storages/PrivateCheckListStorage.swift
@@ -12,6 +12,7 @@ protocol PrivateCheckListStorage {
 	func saveCheckList(id: UUID, title: String, items: [CheckListItem]) async throws
 	func fetchAllCheckList() async throws -> [PrivateCheckListResponseDTO]
 	func fetchCheckList(id: UUID) async throws -> PrivateCheckListResponseDTO
+	func removeAllCheckList() throws
 	func removeCheckList(id: UUID) throws
 	func appendCheckListItem(id: UUID, item: CheckListItem) async throws
 	func updateCheckListItem(id: UUID, item: CheckListItem) async throws

--- a/client/Projects/OpenList/OpenList/Domain/Entites/SettingItem.swift
+++ b/client/Projects/OpenList/OpenList/Domain/Entites/SettingItem.swift
@@ -1,0 +1,12 @@
+//
+//  SettingItem.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Foundation
+
+struct SettingItem {
+	let title: String
+}

--- a/client/Projects/OpenList/OpenList/Domain/Repositories/SettingRepository.swift
+++ b/client/Projects/OpenList/OpenList/Domain/Repositories/SettingRepository.swift
@@ -1,0 +1,13 @@
+//
+//  SettingRepository.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/5/23.
+//
+
+import Foundation
+
+protocol SettingRepository {
+	func logOut() async throws
+	func deleteAccount() async throws
+}

--- a/client/Projects/OpenList/OpenList/Domain/UseCases/SettingUseCase.swift
+++ b/client/Projects/OpenList/OpenList/Domain/UseCases/SettingUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  SettingUseCase.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/5/23.
+//
+
+import Foundation
+
+protocol SettingUseCase {
+	func logOut() async throws
+	func deleteAccount() async throws
+}
+
+final class DefaultSettingUseCase {
+	private let settingRepository: SettingRepository
+	
+	init(settingRepository: SettingRepository) {
+		self.settingRepository = settingRepository
+	}
+}
+
+extension DefaultSettingUseCase: SettingUseCase {
+	func logOut() async throws {
+		try await settingRepository.logOut()
+	}
+	
+	func deleteAccount() async throws {
+		try await settingRepository.deleteAccount()
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/Common/TitleHeaderView.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/Common/TitleHeaderView.swift
@@ -1,0 +1,61 @@
+//
+//  TitleHeaderView.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/5/23.
+//
+
+import UIKit
+
+final class TitleHeaderView: UIView {
+	enum LayoutConstant {
+		static let horizontalPadding: CGFloat = 20
+	}
+	
+	// MARK: - Properties
+	private let titleLabel: UILabel = .init()
+	
+	// MARK: - Initializers
+	override init(frame: CGRect = .zero) {
+		super.init(frame: frame)
+		setViewAttributes()
+		setViewHierarchies()
+		setViewConstraints()
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+extension TitleHeaderView {
+	func configure(title: String) {
+		titleLabel.text = title
+	}
+}
+
+private extension TitleHeaderView {
+	func setViewAttributes() {
+		backgroundColor = .background
+		setTitleLabelAttributes()
+	}
+	
+	func setTitleLabelAttributes() {
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		titleLabel.font = .notoSansCJKkr(type: .medium, size: .extra)
+	}
+	
+	func setViewHierarchies() {
+		addSubview(titleLabel)
+	}
+	
+	func setViewConstraints() {
+		NSLayoutConstraint.activate([
+			titleLabel.topAnchor.constraint(equalTo: topAnchor),
+			titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+			titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstant.horizontalPadding),
+			titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutConstant.horizontalPadding)
+		])
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingAction.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingAction.swift
@@ -9,8 +9,11 @@ import Combine
 
 struct SettingInput {
 	let viewDidLoad: PassthroughSubject<Void, Never>
+	let logOut: PassthroughSubject<Void, Never>
+	let deleteAccount: PassthroughSubject<Void, Never>
 }
 
 enum SettingState {
 	case reload(_ items: [SettingItem])
+	case showLogin
 }

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingAction.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingAction.swift
@@ -1,0 +1,16 @@
+//
+//  SettingAction.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Combine
+
+struct SettingInput {
+	let viewDidLoad: PassthroughSubject<Void, Never>
+}
+
+enum SettingState {
+	case reload(_ items: [SettingItem])
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingRouter.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingRouter.swift
@@ -1,0 +1,19 @@
+//
+//  SettingRouter.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Foundation
+
+final class SettingRouter {
+	weak var viewController: ViewControllable?
+}
+
+// MARK: - RoutingLogic
+extension SettingRouter: SettingRoutingLogic {
+	func dismissSettingScene() {
+		viewController?.popViewController(animated: true)
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingRouter.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingRouter.swift
@@ -9,10 +9,19 @@ import Foundation
 
 final class SettingRouter {
 	weak var viewController: ViewControllable?
+	private var appRouter: AppRouterProtocol
+	
+	init(appRouter: AppRouterProtocol) {
+		self.appRouter = appRouter
+	}
 }
 
 // MARK: - RoutingLogic
 extension SettingRouter: SettingRoutingLogic {
+	func routeToLoginScene() {
+		appRouter.showLoginFlow()
+	}
+	
 	func dismissSettingScene() {
 		viewController?.popViewController(animated: true)
 	}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewController.swift
@@ -9,6 +9,7 @@ import Combine
 import UIKit
 
 protocol SettingRoutingLogic: AnyObject {
+	func routeToLoginScene()
 	func dismissSettingScene()
 }
 
@@ -34,6 +35,8 @@ final class SettingViewController: UIViewController, ViewControllable {
 	
 	// Event Properties
 	private let viewLoad: PassthroughSubject<Void, Never> = .init()
+	private let logOut: PassthroughSubject<Void, Never> = .init()
+	private let deleteAccount: PassthroughSubject<Void, Never> = .init()
 
   // MARK: - Initializers
 	init(
@@ -68,7 +71,11 @@ extension SettingViewController: ViewBindable {
 	typealias OutputError = Error
 
 	func bind() {
-		let input = SettingInput(viewDidLoad: viewLoad)
+		let input = SettingInput(
+			viewDidLoad: viewLoad,
+			logOut: logOut,
+			deleteAccount: deleteAccount
+		)
 		let state = viewModel.transform(input)
 		state
 			.receive(on: DispatchQueue.main)
@@ -82,6 +89,8 @@ extension SettingViewController: ViewBindable {
 		case .reload(let items):
 			dataSource = items
 			settingView.reloadData()
+		case .showLogin:
+			router.routeToLoginScene()
 		}
 	}
 
@@ -171,9 +180,9 @@ extension SettingViewController: UITableViewDelegate {
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		switch indexPath.row {
 		case 0:
-			dump("로그아웃")
+			logOut.send()
 		case 1:
-			dump("회원탈퇴")
+			deleteAccount.send()
 		default: return
 		}
 	}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewController.swift
@@ -1,0 +1,180 @@
+//
+//  SettingViewController.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Combine
+import UIKit
+
+protocol SettingRoutingLogic: AnyObject {
+	func dismissSettingScene()
+}
+
+final class SettingViewController: UIViewController, ViewControllable {
+	enum Constant {
+		static let title: String = "설정"
+		static let previousTitle: String = "카테고리"
+		static let settingItemHeight: CGFloat = 60
+		static let horizontalPadding: CGFloat = 20
+		static let spacingBetweenTitleAndSetting: CGFloat = 24
+	}
+	
+	// MARK: - Properties
+  private let router: SettingRoutingLogic
+  private let viewModel: any SettingViewModelable
+  private var cancellables: Set<AnyCancellable> = []
+	private var dataSource: [SettingItem] = []
+	
+	// UI Components
+	private let settingView: UITableView = .init()
+	private let navigationBar = OpenListNavigationBar(isBackButtonHidden: false, backButtonTitle: Constant.previousTitle)
+	private let titleHaederView: TitleHeaderView = .init()
+	
+	// Event Properties
+	private let viewLoad: PassthroughSubject<Void, Never> = .init()
+
+  // MARK: - Initializers
+	init(
+		router: SettingRoutingLogic,
+		viewModel: some SettingViewModelable
+	) {
+		self.router = router
+		self.viewModel = viewModel
+		super.init(nibName: nil, bundle: nil)
+	}
+
+  @available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	// MARK: - View Life Cycles
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		setViewAttributes()
+		setViewHierarchies()
+		setViewConstraints()
+		bind()
+		viewLoad.send()
+	}
+}
+
+// MARK: - Bind Methods
+extension SettingViewController: ViewBindable {
+	typealias State = SettingState
+	typealias OutputError = Error
+
+	func bind() {
+		let input = SettingInput(viewDidLoad: viewLoad)
+		let state = viewModel.transform(input)
+		state
+			.receive(on: DispatchQueue.main)
+			.withUnretained(self)
+			.sink { (owner, state) in owner.render(state) }
+			.store(in: &cancellables)
+	}
+
+	func render(_ state: State) {
+		switch state {
+		case .reload(let items):
+			dataSource = items
+			settingView.reloadData()
+		}
+	}
+
+	func handleError(_ error: OutputError) {
+		dump(error)
+	}
+}
+
+// MARK: - View Methods
+private extension SettingViewController {
+	func setViewAttributes() {
+		view.backgroundColor = UIColor.background
+		
+		setNavigationAttributes()
+		setSettingViewAttributes()
+		setHeaderViewAttributes()
+	}
+	
+	func setNavigationAttributes() {
+		navigationBar.delegate = self
+	}
+	
+	func setSettingViewAttributes() {
+		settingView.translatesAutoresizingMaskIntoConstraints = false
+		settingView.separatorStyle = .none
+		settingView.registerCell(SettingTableViewCell.self)
+		settingView.delegate = self
+		settingView.dataSource = self
+	}
+	
+	func setHeaderViewAttributes() {
+		titleHaederView.translatesAutoresizingMaskIntoConstraints = false
+		titleHaederView.configure(title: Constant.title)
+	}
+	
+	func setViewHierarchies() {
+		view.addSubview(settingView)
+		view.addSubview(navigationBar)
+		view.addSubview(titleHaederView)
+	}
+	
+	func setViewConstraints() {
+		let safeArea = view.safeAreaLayoutGuide
+		NSLayoutConstraint.activate([
+			titleHaederView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
+			titleHaederView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+			titleHaederView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+			
+			settingView.topAnchor.constraint(
+				equalTo: titleHaederView.bottomAnchor,
+				constant: Constant.spacingBetweenTitleAndSetting
+			),
+			settingView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+			settingView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+			settingView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
+		])
+	}
+}
+
+extension SettingViewController: OpenListNavigationBarDelegate {
+	func openListNavigationBar(_ navigationBar: OpenListNavigationBar, didTapBackButton button: UIButton) {
+		router.dismissSettingScene()
+	}
+	
+	func openListNavigationBar(_ navigationBar: OpenListNavigationBar, didTapBarItem item: OpenListNavigationBarItem) { }
+}
+
+extension SettingViewController: UITableViewDataSource {
+	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		return dataSource.count
+	}
+	
+	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		let cell = tableView.dequeueCell(SettingTableViewCell.self, for: indexPath)
+		let item = dataSource[indexPath.row]
+		cell.configure(with: item)
+		cell.selectionStyle = .none
+		return cell
+	}
+}
+
+extension SettingViewController: UITableViewDelegate {
+	func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+		Constant.settingItemHeight
+	}
+	
+	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		switch indexPath.row {
+		case 0:
+			dump("로그아웃")
+		case 1:
+			dump("회원탈퇴")
+		default: return
+		}
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewFactory.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewFactory.swift
@@ -1,0 +1,30 @@
+//
+//  SettingViewFactory.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Foundation
+
+protocol SettingDependency: Dependency { }
+
+final class SettingComponent: Component<SettingDependency> { }
+
+protocol SettingFactoryable: Factoryable {
+	func make() -> ViewControllable
+}
+
+final class SettingViewFactory: Factory<SettingDependency>, SettingFactoryable {
+	override init(parent: SettingDependency) {
+		super.init(parent: parent)
+	}
+	
+	func make() -> ViewControllable {
+		let router = SettingRouter()
+		let viewModel = SettingViewModel()
+		let viewController = SettingViewController(router: router, viewModel: viewModel)
+		router.viewController = viewController
+		return viewController
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewModel.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/SettingViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  SettingViewModel.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Combine
+
+protocol SettingViewModelable: ViewModelable
+where Input == SettingInput,
+  State == SettingState,
+  Output == AnyPublisher<State, Never> { }
+
+final class SettingViewModel {
+	enum Constant {
+		static let titles = ["로그아웃", "회원탈퇴"]
+	}
+}
+
+extension SettingViewModel: SettingViewModelable {
+  func transform(_ input: Input) -> Output {
+    return Publishers.MergeMany([
+			viewDidLoad(input)
+    ]).eraseToAnyPublisher()
+  }
+}
+
+private extension SettingViewModel {
+	func viewDidLoad(_ input: Input) -> Output {
+		return input.viewDidLoad
+			.map {
+				let items = Constant.titles.map {
+					SettingItem(title: $0)
+				}
+				return .reload(items)
+			}
+			.eraseToAnyPublisher()
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/View/SettingTableViewCell.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/NavigationScene/SettingScene/View/SettingTableViewCell.swift
@@ -1,0 +1,67 @@
+//
+//  SettingTableViewCell.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import UIKit
+
+final class SettingTableViewCell: UITableViewCell {
+	enum LayoutConstant {
+		static let horizontalPadding: CGFloat = 20
+	}
+	
+	// MARK: - Properties
+	private let titleLabel: UILabel = .init()
+	
+	// MARK: - Initializers
+	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+		super.init(style: style, reuseIdentifier: reuseIdentifier)
+		setViewAttributes()
+		setViewHierarchies()
+		setViewConstraints()
+	}
+	
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}
+
+extension SettingTableViewCell {
+	func configure(with item: SettingItem, accessoryView: UIView? = nil) {
+		titleLabel.text = item.title
+		self.accessoryView = accessoryView
+	}
+}
+
+private extension SettingTableViewCell {
+	func setViewAttributes() {
+		backgroundColor = .background
+		setTitleLabelAttributes()
+	}
+	
+	func setTitleLabelAttributes() {
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		titleLabel.font = .notoSansCJKkr(type: .medium, size: .medium)
+	}
+	
+	func setViewHierarchies() {
+		contentView.addSubview(titleLabel)
+	}
+	
+	func setViewConstraints() {
+		NSLayoutConstraint.activate([
+			titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+			titleLabel.leadingAnchor.constraint(
+				equalTo: contentView.leadingAnchor,
+				constant: LayoutConstant.horizontalPadding
+			),
+			titleLabel.trailingAnchor.constraint(
+				equalTo: contentView.trailingAnchor,
+				constant: -LayoutConstant.horizontalPadding
+			)
+		])
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabRouter.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabRouter.swift
@@ -1,0 +1,28 @@
+//
+//  CheckListTabRouter.swift
+//  OpenList
+//
+//  Created by wi_seong on 12/4/23.
+//
+
+import Foundation
+
+final class CheckListTabRouter {
+	weak var viewController: ViewControllable?
+	
+	private var settingFactory: SettingFactoryable
+	weak var settingViewControllable: ViewControllable?
+	
+	init(settingFactory: SettingFactoryable) {
+		self.settingFactory = settingFactory
+	}
+}
+
+// MARK: - CheckListTabRoutingLogic
+extension CheckListTabRouter: CheckListTabRoutingLogic {
+	func showSetting() {
+		let settingViewControllable = settingFactory.make()
+		self.settingViewControllable = settingViewControllable
+		viewController?.pushViewController(settingViewControllable, animated: true)
+	}
+}

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabRouter.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabRouter.swift
@@ -9,11 +9,12 @@ import Foundation
 
 final class CheckListTabRouter {
 	weak var viewController: ViewControllable?
-	
+	private var appRouter: AppRouterProtocol
 	private var settingFactory: SettingFactoryable
 	weak var settingViewControllable: ViewControllable?
 	
-	init(settingFactory: SettingFactoryable) {
+	init(appRouter: AppRouterProtocol, settingFactory: SettingFactoryable) {
+		self.appRouter = appRouter
 		self.settingFactory = settingFactory
 	}
 }
@@ -21,7 +22,7 @@ final class CheckListTabRouter {
 // MARK: - CheckListTabRoutingLogic
 extension CheckListTabRouter: CheckListTabRoutingLogic {
 	func showSetting() {
-		let settingViewControllable = settingFactory.make()
+		let settingViewControllable = settingFactory.make(with: appRouter)
 		self.settingViewControllable = settingViewControllable
 		viewController?.pushViewController(settingViewControllable, animated: true)
 	}

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewController.swift
@@ -17,6 +17,10 @@ enum CheckListTabType: Int, Comparable {
 	}
 }
 
+protocol CheckListTabRoutingLogic: AnyObject {
+	func showSetting()
+}
+
 final class CheckListTabViewController: UIViewController, ViewControllable {
 	// MARK: - Properties
 	private var currentTab: CheckListTabType = .privateTab {
@@ -24,9 +28,11 @@ final class CheckListTabViewController: UIViewController, ViewControllable {
 			paging(from: oldValue, to: currentTab)
 		}
 	}
+	private let router: CheckListTabRoutingLogic
 	
 	// MARK: - UI Components
-	private let navigationBar: OpenListNavigationBar = .init(rightItems: [.bell, .search, .more])
+	/// 네비게이션 뷰 컨트롤러
+	private let navigationBar: OpenListNavigationBar = .init(rightItems: [.more])
 	/// 상단 탭 뷰
 	private let checkListTopTabView: CheckListTopTabView = .init()
 	/// 상단 탭의 인디케이터 뷰
@@ -47,10 +53,12 @@ final class CheckListTabViewController: UIViewController, ViewControllable {
 	
 	// MARK: - Initializers
 	init(
+		router: CheckListTabRoutingLogic,
 		privateCheckListTableFactory: CheckListTableFactoryable,
 		withCheckListFactoryable: WithCheckListFactoryable,
 		sharedCheckListFactory: SharedCheckListFactoryable
 	) {
+		self.router = router
 		self.privateCheckListTableFactory = privateCheckListTableFactory
 		self.withCheckListFactoryable = withCheckListFactoryable
 		self.sharedCheckListFactory = sharedCheckListFactory
@@ -88,6 +96,7 @@ private extension CheckListTabViewController {
 		setCheckListTopViewAttributes()
 		setPageViewControllerAttributes()
 		setIndicatorViewAttributes()
+		setNavigationBarAttributes()
 	}
 	
 	func setCheckListTopViewAttributes() {
@@ -107,6 +116,10 @@ private extension CheckListTabViewController {
 		indicatorView.translatesAutoresizingMaskIntoConstraints = false
 		indicatorView.backgroundColor = .green
 		indicatorView.layer.cornerRadius = 1
+	}
+	
+	func setNavigationBarAttributes() {
+		navigationBar.delegate = self
 	}
 	
 	func setViewHierarchies() {
@@ -254,6 +267,18 @@ private extension CheckListTabViewController {
 			self.indicatorViewCenterConstraint = newIndicatorViewCenterconstraint
 			self.indicatorViewCenterConstraint?.isActive = true
 			self.view.layoutIfNeeded()
+		}
+	}
+}
+
+extension CheckListTabViewController: OpenListNavigationBarDelegate {
+	func openListNavigationBar(_ navigationBar: OpenListNavigationBar, didTapBackButton button: UIButton) { }
+	
+	func openListNavigationBar(_ navigationBar: OpenListNavigationBar, didTapBarItem item: OpenListNavigationBarItem) {
+		switch item.type {
+		case .more:
+			router.showSetting()
+		default: return
 		}
 	}
 }

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewFactory.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewFactory.swift
@@ -20,7 +20,8 @@ final class CheckListTabComponent:
 	Component<CheckListTabDependency>,
 	CheckListTableDependency,
 	WithCheckListDependency,
-	SharedCheckListDependency {
+	SharedCheckListDependency,
+	SettingDependency {
 	var session: CustomSession { parent.session }
 	
 	var crdtStorage: CRDTStorage = DefaultCRDTStorage()
@@ -44,6 +45,10 @@ final class CheckListTabComponent:
 	fileprivate var sharedCheckListFactoryable: SharedCheckListFactoryable {
 		return SharedCheckListViewFactory(parent: self)
 	}
+	
+	fileprivate var settingFactoryable: SettingFactoryable {
+		return SettingViewFactory(parent: self)
+	}
 }
 
 protocol CheckListTabFactoryable: Factoryable {
@@ -57,11 +62,14 @@ final class CheckListTabViewFactory: Factory<CheckListTabDependency>, CheckListT
 	
 	func make() -> ViewControllable {
 		let component = CheckListTabComponent(parent: parent)
+		let router = CheckListTabRouter(settingFactory: component.settingFactoryable)
 		let viewController = CheckListTabViewController(
+			router: router,
 			privateCheckListTableFactory: component.privateCheckListTableFactoryable,
 			withCheckListFactoryable: component.withCheckListFactoryable,
 			sharedCheckListFactory: component.sharedCheckListFactoryable
 		)
+		router.viewController = viewController
 		return viewController
 	}
 }

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewFactory.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/CheckListTabViewFactory.swift
@@ -11,6 +11,7 @@ import Foundation
 
 protocol CheckListTabDependency: Dependency {
 	var session: CustomSession { get }
+	var checkListStorage: PrivateCheckListStorage { get }
 	var persistenceUseCase: PersistenceUseCase { get }
 	var checkListRepository: CheckListRepository { get }
 	var deepLinkSubject: PassthroughSubject<DeepLinkTarget, Never> { get }
@@ -29,6 +30,8 @@ final class CheckListTabComponent:
 	var crdtRepository: CRDTRepository { DefaultCRDTRepository(crdtStorage: crdtStorage) }
 	
 	var persistenceUseCase: PersistenceUseCase { parent.persistenceUseCase }
+	
+	var checkListStorage: PrivateCheckListStorage { parent.checkListStorage }
 	
 	var checkListRepository: CheckListRepository { parent.checkListRepository }
 	
@@ -52,7 +55,7 @@ final class CheckListTabComponent:
 }
 
 protocol CheckListTabFactoryable: Factoryable {
-	func make() -> ViewControllable
+	func make(with appRouter: AppRouterProtocol) -> ViewControllable
 }
 
 final class CheckListTabViewFactory: Factory<CheckListTabDependency>, CheckListTabFactoryable {
@@ -60,9 +63,12 @@ final class CheckListTabViewFactory: Factory<CheckListTabDependency>, CheckListT
 		super.init(parent: parent)
 	}
 	
-	func make() -> ViewControllable {
+	func make(with appRouter: AppRouterProtocol) -> ViewControllable {
 		let component = CheckListTabComponent(parent: parent)
-		let router = CheckListTabRouter(settingFactory: component.settingFactoryable)
+		let router = CheckListTabRouter(
+			appRouter: appRouter,
+			settingFactory: component.settingFactoryable
+		)
 		let viewController = CheckListTabViewController(
 			router: router,
 			privateCheckListTableFactory: component.privateCheckListTableFactoryable,

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewController.swift
@@ -8,15 +8,18 @@
 import UIKit
 
 final class TabBarViewController: UITabBarController, ViewControllable {
+	private let appRouter: AppRouterProtocol
 	private let checkListTabFactoryable: CheckListTabFactoryable
 	private let addTabFactoryable: AddCheckListTitleFactoryable
 	private let recommendTabFactoryable: RecommendTabFactoryable
 	
 	init(
+		appRouter: AppRouterProtocol,
 		checkListTabFactoryable: CheckListTabFactoryable,
 		addTabFactoryable: AddCheckListTitleFactoryable,
 		recommendTabFactoryable: RecommendTabFactoryable
 	) {
+		self.appRouter = appRouter
 		self.checkListTabFactoryable = checkListTabFactoryable
 		self.addTabFactoryable = addTabFactoryable
 		self.recommendTabFactoryable = recommendTabFactoryable
@@ -36,7 +39,7 @@ final class TabBarViewController: UITabBarController, ViewControllable {
 		emptyViewController.view.backgroundColor = .systemBackground
 		emptyViewController.tabBarItem = makeTabBarItem(of: .addTab)
 		
-		let checkListTabViewControllable = checkListTabFactoryable.make()
+		let checkListTabViewControllable = checkListTabFactoryable.make(with: appRouter)
 		let checkListTabNavigationController = makeTabNavigationController(of: checkListTabViewControllable)
 		checkListTabNavigationController.navigationController.tabBarItem = makeTabBarItem(of: .checklistTab)
 		

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewFactory.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/TabBarViewFactory.swift
@@ -56,7 +56,7 @@ final class TabBarComponent:
 }
 
 protocol TabBarFactoryable: Factoryable {
-	func make() -> ViewControllable
+	func make(with appRouter: AppRouterProtocol) -> ViewControllable
 }
 
 final class TabBarViewFactory: Factory<TabBarDependency>, TabBarFactoryable {
@@ -64,9 +64,10 @@ final class TabBarViewFactory: Factory<TabBarDependency>, TabBarFactoryable {
 		super.init(parent: parent)
 	}
 	
-	func make() -> ViewControllable {
+	func make(with appRouter: AppRouterProtocol) -> ViewControllable {
 		let component = TabBarComponent(parent: parent)
 		let tabBarViewController = TabBarViewController(
+			appRouter: appRouter,
 			checkListTabFactoryable: component.checklistTabFactoryable,
 			addTabFactoryable: component.addTabFactoryable,
 			recommendTabFactoryable: component.recommendTabFactoryable

--- a/client/Projects/OpenList/OpenList/Storage/CheckListStorage/DefaultPrivateCheckListStorage.swift
+++ b/client/Projects/OpenList/OpenList/Storage/CheckListStorage/DefaultPrivateCheckListStorage.swift
@@ -125,6 +125,21 @@ extension DefaultPrivateCheckListStorage: PrivateCheckListStorage {
 	}
 	
 	// 체크리스트를 삭제합니다.
+	func removeAllCheckList() throws {
+		let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "PrivateCheckListEntity")
+		do {
+			let entities = try coreDataStorage.viewContext.fetch(fetchRequest)
+			entities
+				.compactMap { $0 as? NSManagedObject }
+				.forEach {
+					coreDataStorage.viewContext.delete($0)
+				}
+			try coreDataStorage.viewContext.save()
+		} catch {
+			throw CoreDataStorageError.saveError(error)
+		}
+	}
+	
 	func removeCheckList(id: UUID) throws {
 		let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "PrivateCheckListEntity")
 		fetchRequest.predicate = NSPredicate(format: "%K == %@", #keyPath(PrivateCheckListEntity.checklistId), id as CVarArg)


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #161 

## 고민과 해결 과정
- 로그인 화면 전환에 대한 고민과 메모리 해제 고민
- Router가 트리 구조이기 때문에 일단은 AppRouter를 주입 받는 식으로 구현
- window가 교체 되면서 가장 밑에 있는 ViewController 부터 순차적으로 메모리 해제됨

## 스크린샷
|실행화면|
|-|
|<img width="300" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/53855302/b72aa06b-1130-4a7f-9b77-6bf3ebc149b6">|

## 테스트 결과(커버리지/테스트 결과)
n/a