### PR TITLE
빈 체크리스트가 삭제되도록 수정

### DIFF
--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/AddTabScene/AddCheckListItemScene/AddCheckListItemViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/AddTabScene/AddCheckListItemScene/AddCheckListItemViewController.swift
@@ -309,7 +309,10 @@ extension AddCheckListItemViewController: SelectCheckListCellDelegate {
 		_ textView: OpenListTextView,
 		cell: SelectCheckListCell,
 		indexPath: IndexPath
-	) { }
+	) {
+		guard let text = textView.text, text.isEmpty  else { return }
+		dataSource?.deleteCheckListItem(at: indexPath)
+	}
 	
 	func textView(
 		_ textView: OpenListTextView,
@@ -346,7 +349,10 @@ extension AddCheckListItemViewController: AiCheckListCellDelegate {
 		_ textView: OpenListTextView,
 		cell: AiCheckListCell,
 		indexPath: IndexPath
-	) { }
+	) {
+		guard let text = textView.text, text.isEmpty  else { return }
+		dataSource?.deleteCheckListItem(at: indexPath)
+	}
 }
 
 // MARK: - WithCheckListItemPlaceholderDelegate


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #205 

## 고민과 해결 과정
성훈님이 작성하신 텍스트 뷰 endEditing 델리게이트에서 체크리스트의 텍스트가 빈 값인 경우 데이터 소스에서 해당 아이템을 삭제하도록 구현했습니다.

## 스크린샷

https://github.com/boostcampwm2023/iOS10-OpenList/assets/48887389/8efd7d65-e8e9-467f-a1cd-ab4628557696


## 테스트 결과(커버리지/테스트 결과)
n/a
