### PR TITLE
[Server] 카테고리별 아이템 개수 확인 및 개수로 item 생성 로직

### DIFF
--- a/server/src/checklist-ai/checklist-ai.controller.ts
+++ b/server/src/checklist-ai/checklist-ai.controller.ts
@@ -1,5 +1,5 @@
 import { ChecklistAiService } from './checklist-ai.service';
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { CreateChecklistItemsDto } from './dto/create-checklist-items.dto';
 
 @Controller('checklist-ai')
@@ -11,8 +11,14 @@ export class ChecklistAiController {
     return this.checklistAiService.generateChecklistItemWithAi(dto);
   }
 
-  @Get('item-count')
+  @Get('count-item')
   async getAiItemCount() {
-    return this.checklistAiService.publishItemCountByCategory();
+    return this.checklistAiService.publishToCountItemsByCategory();
+  }
+
+  // query param으로 count 가지고 옴.
+  @Post('generate-item')
+  async postAiItemGenerate(@Query('count') count: number) {
+    return this.checklistAiService.publishToGenerateItemsLessThanCount(count);
   }
 }

--- a/server/src/checklist-ai/checklist-ai.controller.ts
+++ b/server/src/checklist-ai/checklist-ai.controller.ts
@@ -1,5 +1,5 @@
 import { ChecklistAiService } from './checklist-ai.service';
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { CreateChecklistItemsDto } from './dto/create-checklist-items.dto';
 
 @Controller('checklist-ai')
@@ -9,5 +9,10 @@ export class ChecklistAiController {
   @Post()
   async getChecklistItemsWithAi(@Body() dto: CreateChecklistItemsDto) {
     return this.checklistAiService.generateChecklistItemWithAi(dto);
+  }
+
+  @Get('item-count')
+  async getAiItemCount() {
+    return this.checklistAiService.publishItemCountByCategory();
   }
 }


### PR DESCRIPTION
## 🚀 완료한 기능 혹은 수정 기능
#227 
## 💡 고민과 해결 과정
api의 uri, redis의 채널명과 message 형식을 어떻게 줄지 많이 고민했다.

### 카테고리 별 ai 데이터 개수 출력 pub and 응답
#### URI : `/checklist-ai/count-item`
- 아래 사진과 같이 응답으로 "[mainCategory, subCategory, minorCategory] - 개수"  형태로 배열로 반환한다.
``` ts 
  this.redisPublisher.publish(
      'itemCount',
      JSON.stringify({
        messageData: 'itemCount',
        categories: ["[mainCategory, subCategory, minorCategory] - 개수", "[mainCategory, subCategory, minorCategory] - 개수" ...],
      }),
    );
```
### 카테고리 별 데이터 개수가 입력 값보다 작은 것들에 대해 gpt 데이터 생성 요청 pub
#### URI : `/checklist-ai/generate-item?count=숫자`
- 아래 사진과 같이 쿼리로 [main, sub, minor, categoryId] 형태로 받아와서 ai_generate 채널의 generateGptData 메시지와 카테고리로 pub을 날린다.

```ts
  this.redisPublisher.publish(
      'ai_generate',
      JSON.stringify({
        messageData: 'generateGptData',
        categories: categories,
      }),
    );
```


## 📸 스크린샷
<img width="1297" alt="image" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/f125542d-33ea-45ea-8ede-8155ea8dff2e">

<img width="1291" alt="image" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/b1a434f3-a871-44e0-b79c-07f5b7702fea">


## ✅  테스트 결과(커버리지/테스트 결과)
- Pub도 잘되고
<img width="847" alt="image" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/6619d5cd-5745-4f33-b3ef-80b7636ace0b">

- Sub도 잘된다.
<img width="1447" alt="image" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/52368015/4930c57c-36cd-4e94-9338-de3f0cd16cfc">

