### PR TITLE
함께 체크리스트 Subject 호출 부 변경 및 인원수 표시

### DIFF
--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListAction.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListAction.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 struct WithDetailCheckListInput {
-	let viewWillAppear: PassthroughSubject<Void, Never>
+	let viewLoad: PassthroughSubject<Void, Never>
 	let socketConnet: PassthroughSubject<Void, Never>
 	let textShouldChange: PassthroughSubject<TextChange, Never>
 	let textDidChange: PassthroughSubject<WithCheckListItemChange, Never>
@@ -22,7 +22,7 @@ struct WithDetailCheckListInput {
 
 enum WithDetailCheckListState {
 	case none
-	case viewWillAppear(CheckList)
+	case viewLoad(CheckList)
 	case updateItems([any ListItem])
 	case appendItem(any ListItem)
 	case removeItem(any ListItem)

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListViewController.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListViewController.swift
@@ -36,7 +36,7 @@ final class WithDetailCheckListViewController: UIViewController, ViewControllabl
 	private let headerView: CheckListHeaderView = .init()
 	
 	// Event Properties
-	private let viewWillAppear: PassthroughSubject<Void, Never> = .init()
+	private let viewLoad: PassthroughSubject<Void, Never> = .init()
 	private let socketConnet: PassthroughSubject<Void, Never> = .init()
 	private let textShouldChange: PassthroughSubject<TextChange, Never> = .init()
 	private let textDidChange: PassthroughSubject<WithCheckListItemChange, Never> = .init()
@@ -74,14 +74,8 @@ final class WithDetailCheckListViewController: UIViewController, ViewControllabl
 		setViewAttributes()
 		setViewHierarchies()
 		setViewConstraints()
-//		setWebSocket()
 		bind()
-//		socketConnet.send()
-	}
-	
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
-		viewWillAppear.send(())
+		viewLoad.send(())
 	}
 	
 	deinit {
@@ -96,7 +90,7 @@ extension WithDetailCheckListViewController: ViewBindable {
 	
 	func bind() {
 		let input = WithDetailCheckListInput(
-			viewWillAppear: viewWillAppear,
+			viewLoad: viewLoad,
 			socketConnet: socketConnet,
 			textShouldChange: textShouldChange,
 			textDidChange: textDidChange,
@@ -119,7 +113,7 @@ extension WithDetailCheckListViewController: ViewBindable {
 		switch state {
 		case .none:
 			break
-		case let .viewWillAppear(checkList):
+		case let .viewLoad(checkList):
 			viewAppear(checkList)
 		case let .updateItems(items):
 			updateTextField(to: items)

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListViewModel.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/DetailScene/WithDetailCheckListScene/WithDetailCheckListViewModel.swift
@@ -62,7 +62,7 @@ extension WithDetailCheckListViewModel: WithDetailCheckListViewModelable {
 			
 private extension WithDetailCheckListViewModel {
 	func updateTitle(_ input: Input) -> Output {
-		return input.viewWillAppear
+		return input.viewLoad
 			.withUnretained(self)
 			.flatMap { (owner, _) -> AnyPublisher<CheckList, Never> in
 				let future = Future(asyncFunc: {
@@ -71,7 +71,7 @@ private extension WithDetailCheckListViewModel {
 				return future.eraseToAnyPublisher()
 			}
 			.map { checkList in
-				return .viewWillAppear(checkList)
+				return .viewLoad(checkList)
 			}
 			.eraseToAnyPublisher()
 	}

--- a/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/WithCheckListScene/WithCheckListCell.swift
+++ b/client/Projects/OpenList/OpenList/Scenes/TabbarScene/CheckListTabScene/WithCheckListScene/WithCheckListCell.swift
@@ -34,7 +34,7 @@ final class WithCheckListCell: UICollectionViewCell {
 	
 	func configure(with item: WithCheckList) {
 		titleLabel.text = item.title
-		profileImagesCountLabel.text = "+\(item.users.count)"
+		profileImagesCountLabel.text = "\(item.users.count)명과 함께"
 	}
 }
 


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능

- [x] PassthroughSubject 변수명과 호출 뷰 사이클 변경
- [x] 함께 탭 : 인원수 표기방식 변경

## 고민과 해결 과정

고민은 딱히 없었습니다!

## 스크린샷

<img src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/42074365/27e47f1c-20d3-4e21-80ca-994bc0a473fa" width="375"/>

## 테스트 결과(커버리지/테스트 결과)

n/a