### PR TITLE
CRDT 메모리 누수 해결

### DIFF
--- a/client/Projects/CRDT/CRDT/RGATreeSplitBalanced/RGASNode.swift
+++ b/client/Projects/CRDT/CRDT/RGATreeSplitBalanced/RGASNode.swift
@@ -19,7 +19,7 @@ public final class RGASNode<T: Codable & Equatable>: Codable {
 	var link: RGASNode?
 	
 	/// idNode
-	var tree: RGASTree<T>?
+	weak var tree: RGASTree<T>?
 	
 	/// 컨텐츠
 	var content: [T]?

--- a/client/Projects/CRDT/CRDT/RGATreeSplitBalanced/RGASTree.swift
+++ b/client/Projects/CRDT/CRDT/RGATreeSplitBalanced/RGASTree.swift
@@ -14,10 +14,10 @@ public final class RGASTree<T: Codable & Equatable>: Codable {
 	/// 기본 RGA알고리즘의 링크드 리스트의 노드
 	/// 기본 RGA 노드도 RGASTree을 서로 참조하고 있다.
 	/// 만약 RGA 노드가 툼스톤이 된다면 nil을 가르킨다.
-	weak var root: RGASNode<T>? //
+	var root: RGASNode<T>? //
 	
 	/// 부모를 가르키는 idNode
-	var parent: RGASTree<T>?
+	weak var parent: RGASTree<T>?
 	
 	/// 왼쪽 자식 트리를 가르키는 idNode
 	private(set) var leftChild: RGASTree<T>?

--- a/client/Projects/OpenList/OpenList/Utils/KeyChain/AccessTokenInterceptor.swift
+++ b/client/Projects/OpenList/OpenList/Utils/KeyChain/AccessTokenInterceptor.swift
@@ -8,7 +8,7 @@
 import CustomNetwork
 import Foundation
 
-final class AccessTokenInterceptor: RequestInterceptor {
+struct AccessTokenInterceptor: RequestInterceptor {
 	public func intercept(_ request: URLRequest) -> URLRequest {
 		var request = request
 


### PR DESCRIPTION
## 완료한 기능 혹은 수정 기능
- #236

## 고민과 해결 과정

루트트리와 자식트리가 서로 순환참조가 되어 있어 메모리가 줄줄새고 있었습니다.
그래서 부모는 자식을 강한참조하고, 자식은 부모를 약한 참조하도록 변경하였습니다.
하지만 다른 곳에서 os_nw_array라는 객체에서 메모리가 누수되고 있는데 이건 urlsessionWebSocket 자체의 메모리 릭 같습니다?

## 스크린샷
### 해결 전
<img width="1840" alt="스크린샷 2023-12-13 오후 5 25 35" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/48887389/c837500c-6fc7-4336-a491-9908010c8270">

### 해결 후
<img width="1840" alt="스크린샷 2023-12-13 오후 5 27 31" src="https://github.com/boostcampwm2023/iOS10-OpenList/assets/48887389/c2d8b5ab-d888-42eb-844f-b57b0153a142">

## 테스트 결과(커버리지/테스트 결과)
N/A